### PR TITLE
Enhancement/zone type detection for non standard port

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         if: matrix.distro != 'centos8' && matrix.distro != 'debian10'
 
       - name: List Ansible Collections
-        run: run: ansible-galaxy collection
+        run: ansible-galaxy collection
 
       - name: Run Molecule Primary/Secondary/Forwarder tests
         run: molecule test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
         run: pip3 install ansible molecule molecule-docker yamllint ansible-lint docker netaddr dnspython
         if: matrix.distro != 'centos8' && matrix.distro != 'debian10'
 
+      - name: List Ansible Collections
+        run: run: ansible-galaxy collection
+
       - name: Run Molecule Primary/Secondary/Forwarder tests
         run: molecule test
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,10 @@ jobs:
         run: pip3 install ansible==9.13.0 molecule molecule-docker yamllint ansible-lint docker netaddr dnspython
         if: matrix.distro == 'centos8' || matrix.distro == 'debian10'
 
+      - name: Install ansible dependencies (CentOS 8 / Debian 10).
+        run: ansible-galaxy collection install community.general>=9.5.0
+        if: matrix.distro == 'centos8' || matrix.distro == 'debian10'
+
       - name: Install test dependencies.
         run: pip3 install ansible molecule molecule-docker yamllint ansible-lint docker netaddr dnspython
         if: matrix.distro != 'centos8' && matrix.distro != 'debian10'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,10 @@ jobs:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'
           MOLECULE_DISTRO: ${{ matrix.distro }}
+
+      - name: Run Molecule Shared Inventory tests with non-standard ports
+        run: molecule test --scenario-name shared_inventory_nonstandard_ports
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          MOLECULE_DISTRO: ${{ matrix.distro }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         if: matrix.distro == 'centos8' || matrix.distro == 'debian10'
 
       - name: Install ansible dependencies (CentOS 8 / Debian 10).
-        run: ansible-galaxy collection install community.general>=9.5.0
+        run: ansible-galaxy collection install community.general>=9.5.0 --force
         if: matrix.distro == 'centos8' || matrix.distro == 'debian10'
 
       - name: Install test dependencies.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ name: CI
   workflow_dispatch:
   pull_request:
   push:
-    branches:
-      - master
   schedule:
     - cron: "31 3 * * 1"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         run: pip3 install ansible==9.13.0 molecule molecule-docker yamllint ansible-lint docker netaddr dnspython
         if: matrix.distro == 'centos8' || matrix.distro == 'debian10'
 
+      # community.general version >= 9.5.0 is required for the 'dig' lookup filter to support the 'port' parameter
       - name: Install ansible dependencies (CentOS 8 / Debian 10).
         run: ansible-galaxy collection install community.general>=9.5.0 --force
         if: matrix.distro == 'centos8' || matrix.distro == 'debian10'
@@ -43,9 +44,6 @@ jobs:
       - name: Install test dependencies.
         run: pip3 install ansible molecule molecule-docker yamllint ansible-lint docker netaddr dnspython
         if: matrix.distro != 'centos8' && matrix.distro != 'debian10'
-
-      - name: List Ansible Collections
-        run: ansible-galaxy collection list
 
       - name: Run Molecule Primary/Secondary/Forwarder tests
         run: molecule test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         if: matrix.distro != 'centos8' && matrix.distro != 'debian10'
 
       - name: List Ansible Collections
-        run: ansible-galaxy collection
+        run: ansible-galaxy collection list
 
       - name: Run Molecule Primary/Secondary/Forwarder tests
         run: molecule test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ansible role BIND
 
-[![Actions Status](https://github.com/bertvv/ansible-role-bind/workflows/CI/badge.svg)](https://github.com/bertvv/ansible-role-bind/actions)
+[![CI](https://github.com/Salvoxia/ansible-role-bind/actions/workflows/ci.yml/badge.svg)](https://github.com/Salvoxia/ansible-role-bind/actions/workflows/ci.yml)
 
 An Ansible role for setting up ISC BIND as an **authoritative-only** DNS server for multiple domains. Specifically, the responsibilities of this role are to:
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -5,4 +5,4 @@
   hosts: all
 
   roles:
-    - role: "bertvv.bind"
+    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule/default/host_vars/ns2.yml
+++ b/molecule/default/host_vars/ns2.yml
@@ -1,6 +1,9 @@
 ---
 # Secondary Configuration
-
+bind_listen_ipv4_port:
+  - 553
+bind_listen_ipv6_port:
+  - 553
 bind_zones:
   # Secondary server for domain example.com (use zone type autodetection)
   - name: 'example.com'

--- a/molecule/default/host_vars/ns3.yml
+++ b/molecule/default/host_vars/ns3.yml
@@ -7,7 +7,8 @@ bind_zones:
   - name: 'example.com'
     forwarders:
       - 10.11.0.1
-      - 10.11.0.2
+      - ip: 10.11.0.2
+        port: 553
     networks:
       - '192.0.2'
     ipv6_networks:
@@ -17,7 +18,8 @@ bind_zones:
     type: forward
     forwarders:
       - 10.11.0.1
-      - 10.11.0.2
+      - ip: 10.11.0.2
+        port: 553
     networks:
       - '10.11'
     ipv6_networks:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -26,7 +26,7 @@ platforms:
     networks:
       - name: bind
         ipv4_address: "10.11.0.1"
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian10}-ansible:latest"
     # Command to execute when the container starts
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     # Volumes to mount within the container. Important to enable systemd
@@ -50,7 +50,7 @@ platforms:
     networks:
       - name: bind
         ipv4_address: "10.11.0.2"
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian10}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -68,7 +68,7 @@ platforms:
     networks:
       - name: bind
         ipv4_address: "10.11.0.3"
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian10}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -26,7 +26,7 @@ platforms:
     networks:
       - name: bind
         ipv4_address: "10.11.0.1"
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
     # Command to execute when the container starts
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     # Volumes to mount within the container. Important to enable systemd
@@ -50,7 +50,7 @@ platforms:
     networks:
       - name: bind
         ipv4_address: "10.11.0.2"
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -68,7 +68,7 @@ platforms:
     networks:
       - name: bind
         ipv4_address: "10.11.0.3"
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -25,16 +25,28 @@
       ansible.builtin.shell: ls -la /var/lib/bind
       when: "inventory_hostname == 'ns2'"
       ignore_errors: true
+      register: result
+
+    - debug:
+        var: result
 
     - name: Show Log file
       ansible.builtin.shell: cat /var/lib/bind/data/named.run
       when: "inventory_hostname == 'ns2'"
       ignore_errors: true
+      register: result
+
+    - debug:
+        var: result
 
     - name: Perform test dig
       ansible.builtin.shell: dig @localhost -p 553 ns1.acme-inc.com
       when: "inventory_hostname == 'ns2'"
       ignore_errors: true
+      register: result
+
+    - debug:
+        var: result
       
     - name: IPv4 Forward lookups
       assert:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -20,6 +20,21 @@
       ansible.builtin.set_fact:
         dns_port: 553
       when: "inventory_hostname == 'ns2'"
+
+    - name: List contents of /var/lib/bind
+      ansible.builtin.shell: ls -la /var/lib/bind
+      when: "inventory_hostname == 'ns2'"
+      ignore_errors: true
+
+    - name: Show Log file
+      ansible.builtin.shell: cat /var/lib/bind/data/named.run
+      when: "inventory_hostname == 'ns2'"
+      ignore_errors: true
+
+    - name: Perform test dig
+      ansible.builtin.shell: dig @localhost -p 553 ns1.acme-inc.com
+      when: "inventory_hostname == 'ns2'"
+      ignore_errors: true
       
     - name: IPv4 Forward lookups
       assert:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -14,92 +14,98 @@
     - name: Set local_dns variable for dig
       set_fact:
         local_dns: "{{ '@' + ansible_default_ipv4.address }}"
+        dns_port: 53
 
+    - name: Set dns port for ns2
+      ansible.builtin.set_fact:
+        dns_port: 553
+      when: "inventory_hostname == 'ns2'"
+      
     - name: IPv4 Forward lookups
       assert:
         that:
-          - lookup('dig', 'ns1.acme-inc.com', local_dns )    == '10.11.0.1'
-          - lookup('dig', 'ns2.acme-inc.com', local_dns)     == '10.11.0.2'
-          - lookup('dig', 'srv001.acme-inc.com', local_dns)  == '10.11.1.1'
-          - lookup('dig', 'srv002.acme-inc.com', local_dns)  == '10.11.1.2'
-          - lookup('dig', 'mail001.acme-inc.com', local_dns) == '10.11.2.1'
-          - lookup('dig', 'mail002.acme-inc.com', local_dns) == '10.11.2.2'
-          - lookup('dig', 'mail003.acme-inc.com', local_dns) == '10.11.2.3'
-          - lookup('dig', 'srv010.acme-inc.com', local_dns)  == '10.11.0.10'
-          - lookup('dig', 'srv011.acme-inc.com', local_dns)  == '10.11.0.11'
-          - lookup('dig', 'srv012.acme-inc.com', local_dns)  == '10.11.0.12'
-          - lookup('dig', 'srv001.example.com', local_dns)   == '192.0.2.1'
-          - lookup('dig', 'srv002.example.com', local_dns)   == '192.0.2.2'
-          - lookup('dig', 'mail001.example.com', local_dns)  == '192.0.2.10'
+          - lookup('dig', 'ns1.acme-inc.com', local_dns, port=dns_port)    == '10.11.0.1'
+          - lookup('dig', 'ns2.acme-inc.com', local_dns, port=dns_port)     == '10.11.0.2'
+          - lookup('dig', 'srv001.acme-inc.com', local_dns, port=dns_port)  == '10.11.1.1'
+          - lookup('dig', 'srv002.acme-inc.com', local_dns, port=dns_port)  == '10.11.1.2'
+          - lookup('dig', 'mail001.acme-inc.com', local_dns, port=dns_port) == '10.11.2.1'
+          - lookup('dig', 'mail002.acme-inc.com', local_dns, port=dns_port) == '10.11.2.2'
+          - lookup('dig', 'mail003.acme-inc.com', local_dns, port=dns_port) == '10.11.2.3'
+          - lookup('dig', 'srv010.acme-inc.com', local_dns, port=dns_port)  == '10.11.0.10'
+          - lookup('dig', 'srv011.acme-inc.com', local_dns, port=dns_port)  == '10.11.0.11'
+          - lookup('dig', 'srv012.acme-inc.com', local_dns, port=dns_port)  == '10.11.0.12'
+          - lookup('dig', 'srv001.example.com', local_dns, port=dns_port)   == '192.0.2.1'
+          - lookup('dig', 'srv002.example.com', local_dns, port=dns_port)   == '192.0.2.2'
+          - lookup('dig', 'mail001.example.com', local_dns, port=dns_port)  == '192.0.2.10'
 
     - name: IPv4 Reverse lookups
       assert:
         that:
-          - lookup('dig', '10.11.0.1/PTR', local_dns)  == 'ns1.acme-inc.com.'
-          - lookup('dig', '10.11.0.2/PTR', local_dns)  == 'ns2.acme-inc.com.'
-          - lookup('dig', '10.11.1.1/PTR', local_dns)  == 'srv001.acme-inc.com.'
-          - lookup('dig', '10.11.1.2/PTR', local_dns)  == 'srv002.acme-inc.com.'
-          - lookup('dig', '10.11.2.1/PTR', local_dns)  == 'mail001.acme-inc.com.'
-          - lookup('dig', '10.11.2.2/PTR', local_dns)  == 'mail002.acme-inc.com.'
-          - lookup('dig', '10.11.2.3/PTR', local_dns)  == 'mail003.acme-inc.com.'
-          - lookup('dig', '10.11.0.10/PTR', local_dns) == 'srv010.acme-inc.com.'
-          - lookup('dig', '10.11.0.11/PTR', local_dns) == 'srv011.acme-inc.com.'
-          - lookup('dig', '10.11.0.12/PTR', local_dns) == 'srv012.acme-inc.com.'
-          - lookup('dig', '192.0.2.1/PTR', local_dns)  == 'srv001.example.com.'
-          - lookup('dig', '192.0.2.2/PTR', local_dns)  == 'srv002.example.com.'
-          - lookup('dig', '192.0.2.10/PTR', local_dns) == 'mail001.example.com.'
+          - lookup('dig', '10.11.0.1/PTR', local_dns, port=dns_port)  == 'ns1.acme-inc.com.'
+          - lookup('dig', '10.11.0.2/PTR', local_dns, port=dns_port)  == 'ns2.acme-inc.com.'
+          - lookup('dig', '10.11.1.1/PTR', local_dns, port=dns_port)  == 'srv001.acme-inc.com.'
+          - lookup('dig', '10.11.1.2/PTR', local_dns, port=dns_port)  == 'srv002.acme-inc.com.'
+          - lookup('dig', '10.11.2.1/PTR', local_dns, port=dns_port)  == 'mail001.acme-inc.com.'
+          - lookup('dig', '10.11.2.2/PTR', local_dns, port=dns_port)  == 'mail002.acme-inc.com.'
+          - lookup('dig', '10.11.2.3/PTR', local_dns, port=dns_port)  == 'mail003.acme-inc.com.'
+          - lookup('dig', '10.11.0.10/PTR', local_dns, port=dns_port) == 'srv010.acme-inc.com.'
+          - lookup('dig', '10.11.0.11/PTR', local_dns, port=dns_port) == 'srv011.acme-inc.com.'
+          - lookup('dig', '10.11.0.12/PTR', local_dns, port=dns_port) == 'srv012.acme-inc.com.'
+          - lookup('dig', '192.0.2.1/PTR', local_dns, port=dns_port)  == 'srv001.example.com.'
+          - lookup('dig', '192.0.2.2/PTR', local_dns, port=dns_port)  == 'srv002.example.com.'
+          - lookup('dig', '192.0.2.10/PTR', local_dns, port=dns_port) == 'mail001.example.com.'
 
     - name: IPv4 Alias lookups
       assert:
         that:
-          - lookup('dig', 'www.acme-inc.com', local_dns)      == '10.11.1.1'
-          - lookup('dig', 'mysql.acme-inc.com', local_dns)    == '10.11.1.2'
-          - lookup('dig', 'smtp.acme-inc.com', local_dns)     == '10.11.2.1'
-          - lookup('dig', 'mail-in.acme-inc.com', local_dns)  == '10.11.2.1'
-          - lookup('dig', 'imap.acme-inc.com', local_dns)     == '10.11.2.3'
-          - lookup('dig', 'mail-out.acme-inc.com', local_dns) == '10.11.2.3'
-          - lookup('dig', 'www.example.com', local_dns)       == '192.0.2.1'
+          - lookup('dig', 'www.acme-inc.com', local_dns, port=dns_port)      == '10.11.1.1'
+          - lookup('dig', 'mysql.acme-inc.com', local_dns, port=dns_port)    == '10.11.1.2'
+          - lookup('dig', 'smtp.acme-inc.com', local_dns, port=dns_port)     == '10.11.2.1'
+          - lookup('dig', 'mail-in.acme-inc.com', local_dns, port=dns_port)  == '10.11.2.1'
+          - lookup('dig', 'imap.acme-inc.com', local_dns, port=dns_port)     == '10.11.2.3'
+          - lookup('dig', 'mail-out.acme-inc.com', local_dns, port=dns_port) == '10.11.2.3'
+          - lookup('dig', 'www.example.com', local_dns, port=dns_port)       == '192.0.2.1'
 
     - name: IPv6 Forward lookups
       assert:
         that:
-          - lookup('dig', 'srv001.acme-inc.com/AAAA', local_dns)  == '2001:db8::1'
-          - lookup('dig', 'srv002.acme-inc.com/AAAA', local_dns)  == '2001:db8::2'
-          - lookup('dig', 'mail001.acme-inc.com/AAAA', local_dns) == '2001:db8::d:1'
-          - lookup('dig', 'mail002.acme-inc.com/AAAA', local_dns) == '2001:db8::d:2'
-          - lookup('dig', 'mail003.acme-inc.com/AAAA', local_dns) == '2001:db8::d:3'
-          - lookup('dig', 'srv001.example.com/AAAA', local_dns)   == '2001:db9::1'
+          - lookup('dig', 'srv001.acme-inc.com/AAAA', local_dns, port=dns_port)  == '2001:db8::1'
+          - lookup('dig', 'srv002.acme-inc.com/AAAA', local_dns, port=dns_port)  == '2001:db8::2'
+          - lookup('dig', 'mail001.acme-inc.com/AAAA', local_dns, port=dns_port) == '2001:db8::d:1'
+          - lookup('dig', 'mail002.acme-inc.com/AAAA', local_dns, port=dns_port) == '2001:db8::d:2'
+          - lookup('dig', 'mail003.acme-inc.com/AAAA', local_dns, port=dns_port) == '2001:db8::d:3'
+          - lookup('dig', 'srv001.example.com/AAAA', local_dns, port=dns_port)   == '2001:db9::1'
 
     - name: IPv6 Reverse lookups
       assert:
         that:
-          - lookup('dig', '2001:db8::1/PTR', local_dns)   == 'srv001.acme-inc.com.'
-          - lookup('dig', '2001:db8::2/PTR', local_dns)   == 'srv002.acme-inc.com.'
-          - lookup('dig', '2001:db8::d:1/PTR', local_dns) == 'mail001.acme-inc.com.'
-          - lookup('dig', '2001:db8::d:2/PTR', local_dns) == 'mail002.acme-inc.com.'
-          - lookup('dig', '2001:db8::d:3/PTR', local_dns) == 'mail003.acme-inc.com.'
-          - lookup('dig', '2001:db8::d:3/PTR', local_dns) == 'mail003.acme-inc.com.'
-          - lookup('dig', '2001:db9::1/PTR', local_dns)   == 'srv001.example.com.'
+          - lookup('dig', '2001:db8::1/PTR', local_dns, port=dns_port)   == 'srv001.acme-inc.com.'
+          - lookup('dig', '2001:db8::2/PTR', local_dns, port=dns_port)   == 'srv002.acme-inc.com.'
+          - lookup('dig', '2001:db8::d:1/PTR', local_dns, port=dns_port) == 'mail001.acme-inc.com.'
+          - lookup('dig', '2001:db8::d:2/PTR', local_dns, port=dns_port) == 'mail002.acme-inc.com.'
+          - lookup('dig', '2001:db8::d:3/PTR', local_dns, port=dns_port) == 'mail003.acme-inc.com.'
+          - lookup('dig', '2001:db8::d:3/PTR', local_dns, port=dns_port) == 'mail003.acme-inc.com.'
+          - lookup('dig', '2001:db9::1/PTR', local_dns, port=dns_port)   == 'srv001.example.com.'
 
     - name: NS records lookup
       assert:
         that:
-          - lookup('dig', 'acme-inc.com/NS', local_dns).split(',') | sort | join(',') == 'ns1.acme-inc.com.,ns2.acme-inc.com.'
-          - lookup('dig', 'example.com/NS', local_dns).split(',')  | sort | join(',') == 'ns1.acme-inc.com.,ns2.acme-inc.com.'
+          - lookup('dig', 'acme-inc.com/NS', local_dns, port=dns_port).split(',') | sort | join(',') == 'ns1.acme-inc.com.,ns2.acme-inc.com.'
+          - lookup('dig', 'example.com/NS', local_dns, port=dns_port).split(',')  | sort | join(',') == 'ns1.acme-inc.com.,ns2.acme-inc.com.'
 
     - name: MX records lookup
       assert:
         that:
-          - lookup('dig', 'acme-inc.com/MX', local_dns).split(',') | sort | join(',') == '10 mail001.acme-inc.com.,20 mail002.acme-inc.com.'
-          - lookup('dig', 'example.com/MX', local_dns).split(',')  | sort | join(',') == '10 mail001.example.com.'
+          - lookup('dig', 'acme-inc.com/MX', local_dns, port=dns_port).split(',') | sort | join(',') == '10 mail001.acme-inc.com.,20 mail002.acme-inc.com.'
+          - lookup('dig', 'example.com/MX', local_dns, port=dns_port).split(',')  | sort | join(',') == '10 mail001.example.com.'
 
     - name: Service records lookup
       assert:
         that:
-          - lookup('dig', '_ldap._tcp.acme-inc.com/SRV', local_dns) == '0 100 88 srv010.acme-inc.com.'
+          - lookup('dig', '_ldap._tcp.acme-inc.com/SRV', local_dns, port=dns_port) == '0 100 88 srv010.acme-inc.com.'
 
     - name: TXT records lookup
       assert:
         that:
-          - lookup('dig', '_kerberos.acme-inc.com/TXT', local_dns) == 'KERBEROS.ACME-INC.COM'
-          - lookup('dig', 'acme-inc.com/TXT', local_dns).split(',') | sort | join(',') == 'more text,some text'
+          - lookup('dig', '_kerberos.acme-inc.com/TXT', local_dns, port=dns_port) == 'KERBEROS.ACME-INC.COM'
+          - lookup('dig', 'acme-inc.com/TXT', local_dns, port=dns_port).split(',') | sort | join(',') == 'more text,some text'

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -2,7 +2,6 @@
 - name: Verify
   hosts: all
   gather_facts: false
-
   tasks:
 
     # Only collect network facts to reduce setup time
@@ -21,33 +20,6 @@
         dns_port: 553
       when: "inventory_hostname == 'ns2'"
 
-    - name: List contents of /var/lib/bind
-      ansible.builtin.shell: ls -la /var/lib/bind
-      when: "inventory_hostname == 'ns2'"
-      ignore_errors: true
-      register: result
-
-    - debug:
-        var: result
-
-    - name: Show Log file
-      ansible.builtin.shell: cat /var/lib/bind/data/named.run
-      when: "inventory_hostname == 'ns2'"
-      ignore_errors: true
-      register: result
-
-    - debug:
-        var: result
-
-    - name: Perform test dig
-      ansible.builtin.shell: dig @localhost -p 553 ns1.acme-inc.com
-      when: "inventory_hostname == 'ns2'"
-      ignore_errors: true
-      register: result
-
-    - debug:
-        var: result
-      
     - name: IPv4 Forward lookups
       assert:
         that:

--- a/molecule/shared_inventory/molecule.yml
+++ b/molecule/shared_inventory/molecule.yml
@@ -25,7 +25,7 @@ platforms:
     networks:
       - name: bind
         ipv4_address: "10.11.0.4"
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -45,7 +45,7 @@ platforms:
     networks:
       - name: bind
         ipv4_address: "10.11.0.5"
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw

--- a/molecule/shared_inventory_nonstandard_ports/converge.yml
+++ b/molecule/shared_inventory_nonstandard_ports/converge.yml
@@ -1,0 +1,9 @@
+---
+
+# Remark that common variables are defined in `group_vars/all.yml`
+
+- name: Primary/Secondary with Shared Inventory
+  hosts: dns
+
+  roles:
+    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule/shared_inventory_nonstandard_ports/group_vars/all.yml
+++ b/molecule/shared_inventory_nonstandard_ports/group_vars/all.yml
@@ -1,0 +1,119 @@
+---
+bind_statistics_channels: true
+bind_statistics_allow:
+  - any
+bind_zone_dir: /var/local/named-zones
+bind_zone_file_mode: '0660'
+bind_allow_query:
+  - any
+bind_listen_ipv4:
+  - 553
+bind_listen_ipv6:
+  - any
+bind_acls:
+  - name: acl1
+    match_list:
+      - 10.11.0/16
+bind_forwarders:
+  - '8.8.8.8'
+  - '8.8.4.4'
+bind_recursion: true
+bind_dns64: true
+bind_query_log: 'data/query.log'
+bind_check_names: 'master ignore'
+bind_zone_minimum_ttl: "2D"
+bind_zone_ttl: "2W"
+bind_zone_time_to_refresh: "2D"
+bind_zone_time_to_retry: "2H"
+bind_zone_time_to_expire: "2W"
+
+bind_zones:
+  - name: 'example.com'
+    primaries:
+      - '10.11.0.4 port 553'
+    networks:
+      - '192.0.2'
+    ipv6_networks:
+      - '2001:db9::/48'
+    name_servers:
+      - ns1.acme-inc.com.
+      - ns2.acme-inc.com.
+    hostmaster_email: admin
+    hosts:
+      - name: srv001
+        ip: 192.0.2.1
+        ipv6: '2001:db9::1'
+        aliases:
+          - www
+      - name: srv002
+        ip: 192.0.2.2
+        ipv6: '2001:db9::2'
+      - name: mail001
+        ip: 192.0.2.10
+        ipv6: '2001:db9::3'
+    mail_servers:
+      - name: mail001
+        preference: 10
+  - name: 'acme-inc.com'
+    primaries:
+      - 10.11.0.4
+    networks:
+      - '10.11'
+    ipv6_networks:
+      - '2001:db8::/48'
+    name_servers:
+      - ns1
+      - ns2
+    hosts:
+      - name: ns1
+        ip: 10.11.0.4
+      - name: ns2
+        ip: 10.11.0.5
+      - name: srv001
+        ip: 10.11.1.1
+        ipv6: 2001:db8::1
+        aliases:
+          - www
+      - name: srv002
+        ip: 10.11.1.2
+        ipv6: 2001:db8::2
+        aliases:
+          - mysql
+      - name: mail001
+        ip: 10.11.2.1
+        ipv6: 2001:db8::d:1
+        aliases:
+          - smtp
+          - mail-in
+      - name: mail002
+        ip: 10.11.2.2
+        ipv6: 2001:db8::d:2
+      - name: mail003
+        ip: 10.11.2.3
+        ipv6: 2001:db8::d:3
+        aliases:
+          - imap
+          - mail-out
+      - name: srv010
+        ip: 10.11.0.10
+      - name: srv011
+        ip: 10.11.0.11
+      - name: srv012
+        ip: 10.11.0.12
+    mail_servers:
+      - name: mail001
+        preference: 10
+      - name: mail002
+        preference: 20
+    services:
+      - name: _ldap._tcp
+        weight: 100
+        port: 88
+        target: srv010
+    text:
+      - name: _kerberos
+        text: KERBEROS.ACME-INC.COM
+      - name: '@'
+        text:
+          - 'some text'
+          - 'more text'

--- a/molecule/shared_inventory_nonstandard_ports/group_vars/all.yml
+++ b/molecule/shared_inventory_nonstandard_ports/group_vars/all.yml
@@ -7,9 +7,13 @@ bind_zone_file_mode: '0660'
 bind_allow_query:
   - any
 bind_listen_ipv4:
-  - 553
+  - any
 bind_listen_ipv6:
   - any
+bind_listen_ipv4_port:
+  - 553
+bind_listen_ipv6_port:
+  - 553
 bind_acls:
   - name: acl1
     match_list:
@@ -30,7 +34,8 @@ bind_zone_time_to_expire: "2W"
 bind_zones:
   - name: 'example.com'
     primaries:
-      - '10.11.0.4 port 553'
+      - ip: 10.11.0.4
+        port: 553
     networks:
       - '192.0.2'
     ipv6_networks:
@@ -56,7 +61,8 @@ bind_zones:
         preference: 10
   - name: 'acme-inc.com'
     primaries:
-      - 10.11.0.4
+      - ip: 10.11.0.4
+        port: 553
     networks:
       - '10.11'
     ipv6_networks:
@@ -64,6 +70,9 @@ bind_zones:
     name_servers:
       - ns1
       - ns2
+    also_notify:
+      - ip: 10.11.0.5
+        port: 553
     hosts:
       - name: ns1
         ip: 10.11.0.4

--- a/molecule/shared_inventory_nonstandard_ports/molecule.yml
+++ b/molecule/shared_inventory_nonstandard_ports/molecule.yml
@@ -25,7 +25,7 @@ platforms:
     networks:
       - name: bind
         ipv4_address: "10.11.0.4"
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -45,7 +45,7 @@ platforms:
     networks:
       - name: bind
         ipv4_address: "10.11.0.5"
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw

--- a/molecule/shared_inventory_nonstandard_ports/molecule.yml
+++ b/molecule/shared_inventory_nonstandard_ports/molecule.yml
@@ -1,0 +1,72 @@
+---
+dependency:
+  name: galaxy
+
+driver:
+  # Specifies the driver that should be used. Podman should also work
+  name: docker
+
+lint: |
+  set -e
+  yamllint .
+  ansible-lint -x 106 .
+
+platforms:
+  # Set name and hostname
+  - name: ns4
+    groups:
+      - dns
+    hostname: ns4
+    docker_networks:
+      - name: bind
+        ipam_config:
+          - subnet: "10.11.0.0/16"
+            gateway: "10.11.0.254"
+    networks:
+      - name: bind
+        ipv4_address: "10.11.0.4"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - ${PWD}:/etc/ansible/roles/bertvv.bind:ro
+      - ${PWD}/library:/root/.ansible/plugins/modules:ro
+    privileged: true
+    cgroupns_mode: host
+    pre_build_image: true
+    tty: true
+    environment:
+      container: docker
+
+  - name: ns5
+    hostname: ns5
+    groups:
+      - dns
+    networks:
+      - name: bind
+        ipv4_address: "10.11.0.5"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - ${PWD}:/etc/ansible/roles/bertvv.bind:ro
+      - ${PWD}/library:/root/.ansible/plugins/modules:ro
+    privileged: true
+    cgroupns_mode: host
+    pre_build_image: true
+    tty: true
+    environment:
+      container: docker
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_legacy_silent
+      callback_whitelist: profile_tasks
+    ssh_connection:
+      pipelining: true
+
+# Runs the verify.yml playbook
+verifier:
+  name: ansible

--- a/molecule/shared_inventory_nonstandard_ports/verify.yml
+++ b/molecule/shared_inventory_nonstandard_ports/verify.yml
@@ -1,0 +1,105 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+
+  tasks:
+
+    # Only collect network facts to reduce setup time
+    - name: Gathering Facts
+      setup:
+        gather_subset:
+          - 'network'
+
+    - name: Set local_dns variable for dig
+      set_fact:
+        local_dns: "{{ '@' + ansible_default_ipv4.address }}"
+
+    - name: IPv4 Forward lookups
+      assert:
+        that:
+          - lookup('dig', 'ns1.acme-inc.com', local_dns )    == '10.11.0.4'
+          - lookup('dig', 'ns2.acme-inc.com', local_dns)     == '10.11.0.5'
+          - lookup('dig', 'srv001.acme-inc.com', local_dns)  == '10.11.1.1'
+          - lookup('dig', 'srv002.acme-inc.com', local_dns)  == '10.11.1.2'
+          - lookup('dig', 'mail001.acme-inc.com', local_dns) == '10.11.2.1'
+          - lookup('dig', 'mail002.acme-inc.com', local_dns) == '10.11.2.2'
+          - lookup('dig', 'mail003.acme-inc.com', local_dns) == '10.11.2.3'
+          - lookup('dig', 'srv010.acme-inc.com', local_dns)  == '10.11.0.10'
+          - lookup('dig', 'srv011.acme-inc.com', local_dns)  == '10.11.0.11'
+          - lookup('dig', 'srv012.acme-inc.com', local_dns)  == '10.11.0.12'
+          - lookup('dig', 'srv001.example.com', local_dns)   == '192.0.2.1'
+          - lookup('dig', 'srv002.example.com', local_dns)   == '192.0.2.2'
+          - lookup('dig', 'mail001.example.com', local_dns)  == '192.0.2.10'
+
+    - name: IPv4 Reverse lookups
+      assert:
+        that:
+          - lookup('dig', '10.11.0.4/PTR', local_dns)  == 'ns1.acme-inc.com.'
+          - lookup('dig', '10.11.0.5/PTR', local_dns)  == 'ns2.acme-inc.com.'
+          - lookup('dig', '10.11.1.1/PTR', local_dns)  == 'srv001.acme-inc.com.'
+          - lookup('dig', '10.11.1.2/PTR', local_dns)  == 'srv002.acme-inc.com.'
+          - lookup('dig', '10.11.2.1/PTR', local_dns)  == 'mail001.acme-inc.com.'
+          - lookup('dig', '10.11.2.2/PTR', local_dns)  == 'mail002.acme-inc.com.'
+          - lookup('dig', '10.11.2.3/PTR', local_dns)  == 'mail003.acme-inc.com.'
+          - lookup('dig', '10.11.0.10/PTR', local_dns) == 'srv010.acme-inc.com.'
+          - lookup('dig', '10.11.0.11/PTR', local_dns) == 'srv011.acme-inc.com.'
+          - lookup('dig', '10.11.0.12/PTR', local_dns) == 'srv012.acme-inc.com.'
+          - lookup('dig', '192.0.2.1/PTR', local_dns)  == 'srv001.example.com.'
+          - lookup('dig', '192.0.2.2/PTR', local_dns)  == 'srv002.example.com.'
+          - lookup('dig', '192.0.2.10/PTR', local_dns) == 'mail001.example.com.'
+
+    - name: IPv4 Alias lookups
+      assert:
+        that:
+          - lookup('dig', 'www.acme-inc.com', local_dns)      == '10.11.1.1'
+          - lookup('dig', 'mysql.acme-inc.com', local_dns)    == '10.11.1.2'
+          - lookup('dig', 'smtp.acme-inc.com', local_dns)     == '10.11.2.1'
+          - lookup('dig', 'mail-in.acme-inc.com', local_dns)  == '10.11.2.1'
+          - lookup('dig', 'imap.acme-inc.com', local_dns)     == '10.11.2.3'
+          - lookup('dig', 'mail-out.acme-inc.com', local_dns) == '10.11.2.3'
+          - lookup('dig', 'www.example.com', local_dns)       == '192.0.2.1'
+
+    - name: IPv6 Forward lookups
+      assert:
+        that:
+          - lookup('dig', 'srv001.acme-inc.com/AAAA', local_dns)  == '2001:db8::1'
+          - lookup('dig', 'srv002.acme-inc.com/AAAA', local_dns)  == '2001:db8::2'
+          - lookup('dig', 'mail001.acme-inc.com/AAAA', local_dns) == '2001:db8::d:1'
+          - lookup('dig', 'mail002.acme-inc.com/AAAA', local_dns) == '2001:db8::d:2'
+          - lookup('dig', 'mail003.acme-inc.com/AAAA', local_dns) == '2001:db8::d:3'
+          - lookup('dig', 'srv001.example.com/AAAA', local_dns)   == '2001:db9::1'
+
+    - name: IPv6 Reverse lookups
+      assert:
+        that:
+          - lookup('dig', '2001:db8::1/PTR', local_dns)   == 'srv001.acme-inc.com.'
+          - lookup('dig', '2001:db8::2/PTR', local_dns)   == 'srv002.acme-inc.com.'
+          - lookup('dig', '2001:db8::d:1/PTR', local_dns) == 'mail001.acme-inc.com.'
+          - lookup('dig', '2001:db8::d:2/PTR', local_dns) == 'mail002.acme-inc.com.'
+          - lookup('dig', '2001:db8::d:3/PTR', local_dns) == 'mail003.acme-inc.com.'
+          - lookup('dig', '2001:db8::d:3/PTR', local_dns) == 'mail003.acme-inc.com.'
+          - lookup('dig', '2001:db9::1/PTR', local_dns)   == 'srv001.example.com.'
+
+    - name: NS records lookup
+      assert:
+        that:
+          - lookup('dig', 'acme-inc.com/NS', local_dns).split(',') | sort | join(',') == 'ns1.acme-inc.com.,ns2.acme-inc.com.'
+          - lookup('dig', 'example.com/NS', local_dns).split(',')  | sort | join(',') == 'ns1.acme-inc.com.,ns2.acme-inc.com.'
+
+    - name: MX records lookup
+      assert:
+        that:
+          - lookup('dig', 'acme-inc.com/MX', local_dns).split(',') | sort | join(',') == '10 mail001.acme-inc.com.,20 mail002.acme-inc.com.'
+          - lookup('dig', 'example.com/MX', local_dns).split(',')  | sort | join(',') == '10 mail001.example.com.'
+
+    - name: Service records lookup
+      assert:
+        that:
+          - lookup('dig', '_ldap._tcp.acme-inc.com/SRV', local_dns) == '0 100 88 srv010.acme-inc.com.'
+
+    - name: TXT records lookup
+      assert:
+        that:
+          - lookup('dig', '_kerberos.acme-inc.com/TXT', local_dns) == 'KERBEROS.ACME-INC.COM'
+          - lookup('dig', 'acme-inc.com/TXT', local_dns).split(',') | sort | join(',') == 'more text,some text'

--- a/molecule/shared_inventory_nonstandard_ports/verify.yml
+++ b/molecule/shared_inventory_nonstandard_ports/verify.yml
@@ -11,95 +11,96 @@
         gather_subset:
           - 'network'
 
-    - name: Set local_dns variable for dig
+    - name: Set local_dns, dns_port variable for dig
       set_fact:
         local_dns: "{{ '@' + ansible_default_ipv4.address }}"
+        dns_port: 553
 
     - name: IPv4 Forward lookups
       assert:
         that:
-          - lookup('dig', 'ns1.acme-inc.com', local_dns )    == '10.11.0.4'
-          - lookup('dig', 'ns2.acme-inc.com', local_dns)     == '10.11.0.5'
-          - lookup('dig', 'srv001.acme-inc.com', local_dns)  == '10.11.1.1'
-          - lookup('dig', 'srv002.acme-inc.com', local_dns)  == '10.11.1.2'
-          - lookup('dig', 'mail001.acme-inc.com', local_dns) == '10.11.2.1'
-          - lookup('dig', 'mail002.acme-inc.com', local_dns) == '10.11.2.2'
-          - lookup('dig', 'mail003.acme-inc.com', local_dns) == '10.11.2.3'
-          - lookup('dig', 'srv010.acme-inc.com', local_dns)  == '10.11.0.10'
-          - lookup('dig', 'srv011.acme-inc.com', local_dns)  == '10.11.0.11'
-          - lookup('dig', 'srv012.acme-inc.com', local_dns)  == '10.11.0.12'
-          - lookup('dig', 'srv001.example.com', local_dns)   == '192.0.2.1'
-          - lookup('dig', 'srv002.example.com', local_dns)   == '192.0.2.2'
-          - lookup('dig', 'mail001.example.com', local_dns)  == '192.0.2.10'
+          - lookup('dig', 'ns1.acme-inc.com', local_dns, port=dns_port)    == '10.11.0.4'
+          - lookup('dig', 'ns2.acme-inc.com', local_dns, port=dns_port)     == '10.11.0.5'
+          - lookup('dig', 'srv001.acme-inc.com', local_dns, port=dns_port)  == '10.11.1.1'
+          - lookup('dig', 'srv002.acme-inc.com', local_dns, port=dns_port)  == '10.11.1.2'
+          - lookup('dig', 'mail001.acme-inc.com', local_dns, port=dns_port) == '10.11.2.1'
+          - lookup('dig', 'mail002.acme-inc.com', local_dns, port=dns_port) == '10.11.2.2'
+          - lookup('dig', 'mail003.acme-inc.com', local_dns, port=dns_port) == '10.11.2.3'
+          - lookup('dig', 'srv010.acme-inc.com', local_dns, port=dns_port)  == '10.11.0.10'
+          - lookup('dig', 'srv011.acme-inc.com', local_dns, port=dns_port)  == '10.11.0.11'
+          - lookup('dig', 'srv012.acme-inc.com', local_dns, port=dns_port)  == '10.11.0.12'
+          - lookup('dig', 'srv001.example.com', local_dns, port=dns_port)   == '192.0.2.1'
+          - lookup('dig', 'srv002.example.com', local_dns, port=dns_port)   == '192.0.2.2'
+          - lookup('dig', 'mail001.example.com', local_dns, port=dns_port)  == '192.0.2.10'
 
     - name: IPv4 Reverse lookups
       assert:
         that:
-          - lookup('dig', '10.11.0.4/PTR', local_dns)  == 'ns1.acme-inc.com.'
-          - lookup('dig', '10.11.0.5/PTR', local_dns)  == 'ns2.acme-inc.com.'
-          - lookup('dig', '10.11.1.1/PTR', local_dns)  == 'srv001.acme-inc.com.'
-          - lookup('dig', '10.11.1.2/PTR', local_dns)  == 'srv002.acme-inc.com.'
-          - lookup('dig', '10.11.2.1/PTR', local_dns)  == 'mail001.acme-inc.com.'
-          - lookup('dig', '10.11.2.2/PTR', local_dns)  == 'mail002.acme-inc.com.'
-          - lookup('dig', '10.11.2.3/PTR', local_dns)  == 'mail003.acme-inc.com.'
-          - lookup('dig', '10.11.0.10/PTR', local_dns) == 'srv010.acme-inc.com.'
-          - lookup('dig', '10.11.0.11/PTR', local_dns) == 'srv011.acme-inc.com.'
-          - lookup('dig', '10.11.0.12/PTR', local_dns) == 'srv012.acme-inc.com.'
-          - lookup('dig', '192.0.2.1/PTR', local_dns)  == 'srv001.example.com.'
-          - lookup('dig', '192.0.2.2/PTR', local_dns)  == 'srv002.example.com.'
-          - lookup('dig', '192.0.2.10/PTR', local_dns) == 'mail001.example.com.'
+          - lookup('dig', '10.11.0.4/PTR', local_dns, port=dns_port)  == 'ns1.acme-inc.com.'
+          - lookup('dig', '10.11.0.5/PTR', local_dns, port=dns_port)  == 'ns2.acme-inc.com.'
+          - lookup('dig', '10.11.1.1/PTR', local_dns, port=dns_port)  == 'srv001.acme-inc.com.'
+          - lookup('dig', '10.11.1.2/PTR', local_dns, port=dns_port)  == 'srv002.acme-inc.com.'
+          - lookup('dig', '10.11.2.1/PTR', local_dns, port=dns_port)  == 'mail001.acme-inc.com.'
+          - lookup('dig', '10.11.2.2/PTR', local_dns, port=dns_port)  == 'mail002.acme-inc.com.'
+          - lookup('dig', '10.11.2.3/PTR', local_dns, port=dns_port)  == 'mail003.acme-inc.com.'
+          - lookup('dig', '10.11.0.10/PTR', local_dns, port=dns_port) == 'srv010.acme-inc.com.'
+          - lookup('dig', '10.11.0.11/PTR', local_dns, port=dns_port) == 'srv011.acme-inc.com.'
+          - lookup('dig', '10.11.0.12/PTR', local_dns, port=dns_port) == 'srv012.acme-inc.com.'
+          - lookup('dig', '192.0.2.1/PTR', local_dns, port=dns_port)  == 'srv001.example.com.'
+          - lookup('dig', '192.0.2.2/PTR', local_dns, port=dns_port)  == 'srv002.example.com.'
+          - lookup('dig', '192.0.2.10/PTR', local_dns, port=dns_port) == 'mail001.example.com.'
 
     - name: IPv4 Alias lookups
       assert:
         that:
-          - lookup('dig', 'www.acme-inc.com', local_dns)      == '10.11.1.1'
-          - lookup('dig', 'mysql.acme-inc.com', local_dns)    == '10.11.1.2'
-          - lookup('dig', 'smtp.acme-inc.com', local_dns)     == '10.11.2.1'
-          - lookup('dig', 'mail-in.acme-inc.com', local_dns)  == '10.11.2.1'
-          - lookup('dig', 'imap.acme-inc.com', local_dns)     == '10.11.2.3'
-          - lookup('dig', 'mail-out.acme-inc.com', local_dns) == '10.11.2.3'
-          - lookup('dig', 'www.example.com', local_dns)       == '192.0.2.1'
+          - lookup('dig', 'www.acme-inc.com', local_dns, port=dns_port)      == '10.11.1.1'
+          - lookup('dig', 'mysql.acme-inc.com', local_dns, port=dns_port)    == '10.11.1.2'
+          - lookup('dig', 'smtp.acme-inc.com', local_dns, port=dns_port)     == '10.11.2.1'
+          - lookup('dig', 'mail-in.acme-inc.com', local_dns, port=dns_port)  == '10.11.2.1'
+          - lookup('dig', 'imap.acme-inc.com', local_dns, port=dns_port)     == '10.11.2.3'
+          - lookup('dig', 'mail-out.acme-inc.com', local_dns, port=dns_port) == '10.11.2.3'
+          - lookup('dig', 'www.example.com', local_dns, port=dns_port)       == '192.0.2.1'
 
     - name: IPv6 Forward lookups
       assert:
         that:
-          - lookup('dig', 'srv001.acme-inc.com/AAAA', local_dns)  == '2001:db8::1'
-          - lookup('dig', 'srv002.acme-inc.com/AAAA', local_dns)  == '2001:db8::2'
-          - lookup('dig', 'mail001.acme-inc.com/AAAA', local_dns) == '2001:db8::d:1'
-          - lookup('dig', 'mail002.acme-inc.com/AAAA', local_dns) == '2001:db8::d:2'
-          - lookup('dig', 'mail003.acme-inc.com/AAAA', local_dns) == '2001:db8::d:3'
-          - lookup('dig', 'srv001.example.com/AAAA', local_dns)   == '2001:db9::1'
+          - lookup('dig', 'srv001.acme-inc.com/AAAA', local_dns, port=dns_port)  == '2001:db8::1'
+          - lookup('dig', 'srv002.acme-inc.com/AAAA', local_dns, port=dns_port)  == '2001:db8::2'
+          - lookup('dig', 'mail001.acme-inc.com/AAAA', local_dns, port=dns_port) == '2001:db8::d:1'
+          - lookup('dig', 'mail002.acme-inc.com/AAAA', local_dns, port=dns_port) == '2001:db8::d:2'
+          - lookup('dig', 'mail003.acme-inc.com/AAAA', local_dns, port=dns_port) == '2001:db8::d:3'
+          - lookup('dig', 'srv001.example.com/AAAA', local_dns, port=dns_port)   == '2001:db9::1'
 
     - name: IPv6 Reverse lookups
       assert:
         that:
-          - lookup('dig', '2001:db8::1/PTR', local_dns)   == 'srv001.acme-inc.com.'
-          - lookup('dig', '2001:db8::2/PTR', local_dns)   == 'srv002.acme-inc.com.'
-          - lookup('dig', '2001:db8::d:1/PTR', local_dns) == 'mail001.acme-inc.com.'
-          - lookup('dig', '2001:db8::d:2/PTR', local_dns) == 'mail002.acme-inc.com.'
-          - lookup('dig', '2001:db8::d:3/PTR', local_dns) == 'mail003.acme-inc.com.'
-          - lookup('dig', '2001:db8::d:3/PTR', local_dns) == 'mail003.acme-inc.com.'
-          - lookup('dig', '2001:db9::1/PTR', local_dns)   == 'srv001.example.com.'
+          - lookup('dig', '2001:db8::1/PTR', local_dns, port=dns_port)   == 'srv001.acme-inc.com.'
+          - lookup('dig', '2001:db8::2/PTR', local_dns, port=dns_port)   == 'srv002.acme-inc.com.'
+          - lookup('dig', '2001:db8::d:1/PTR', local_dns, port=dns_port) == 'mail001.acme-inc.com.'
+          - lookup('dig', '2001:db8::d:2/PTR', local_dns, port=dns_port) == 'mail002.acme-inc.com.'
+          - lookup('dig', '2001:db8::d:3/PTR', local_dns, port=dns_port) == 'mail003.acme-inc.com.'
+          - lookup('dig', '2001:db8::d:3/PTR', local_dns, port=dns_port) == 'mail003.acme-inc.com.'
+          - lookup('dig', '2001:db9::1/PTR', local_dns, port=dns_port)   == 'srv001.example.com.'
 
     - name: NS records lookup
       assert:
         that:
-          - lookup('dig', 'acme-inc.com/NS', local_dns).split(',') | sort | join(',') == 'ns1.acme-inc.com.,ns2.acme-inc.com.'
-          - lookup('dig', 'example.com/NS', local_dns).split(',')  | sort | join(',') == 'ns1.acme-inc.com.,ns2.acme-inc.com.'
+          - lookup('dig', 'acme-inc.com/NS', local_dns, port=dns_port).split(',') | sort | join(',') == 'ns1.acme-inc.com.,ns2.acme-inc.com.'
+          - lookup('dig', 'example.com/NS', local_dns, port=dns_port).split(',')  | sort | join(',') == 'ns1.acme-inc.com.,ns2.acme-inc.com.'
 
     - name: MX records lookup
       assert:
         that:
-          - lookup('dig', 'acme-inc.com/MX', local_dns).split(',') | sort | join(',') == '10 mail001.acme-inc.com.,20 mail002.acme-inc.com.'
-          - lookup('dig', 'example.com/MX', local_dns).split(',')  | sort | join(',') == '10 mail001.example.com.'
+          - lookup('dig', 'acme-inc.com/MX', local_dns, port=dns_port).split(',') | sort | join(',') == '10 mail001.acme-inc.com.,20 mail002.acme-inc.com.'
+          - lookup('dig', 'example.com/MX', local_dns, port=dns_port).split(',')  | sort | join(',') == '10 mail001.example.com.'
 
     - name: Service records lookup
       assert:
         that:
-          - lookup('dig', '_ldap._tcp.acme-inc.com/SRV', local_dns) == '0 100 88 srv010.acme-inc.com.'
+          - lookup('dig', '_ldap._tcp.acme-inc.com/SRV', local_dns, port=dns_port) == '0 100 88 srv010.acme-inc.com.'
 
     - name: TXT records lookup
       assert:
         that:
-          - lookup('dig', '_kerberos.acme-inc.com/TXT', local_dns) == 'KERBEROS.ACME-INC.COM'
-          - lookup('dig', 'acme-inc.com/TXT', local_dns).split(',') | sort | join(',') == 'more text,some text'
+          - lookup('dig', '_kerberos.acme-inc.com/TXT', local_dns, port=dns_port) == 'KERBEROS.ACME-INC.COM'
+          - lookup('dig', 'acme-inc.com/TXT', local_dns, port=dns_port).split(',') | sort | join(',') == 'more text,some text'

--- a/tasks/build_host_dicts.yml
+++ b/tasks/build_host_dicts.yml
@@ -1,0 +1,45 @@
+---
+- name: Build primaries dict
+  when: zone.primaries is defined
+  block:
+    - name: Convert primaries with port
+      ansible.builtin.set_fact:
+        zone_auxiliary: "{{ zone_auxiliary | default({}) | combine( { zone.name: {'primaries_dict': { item.ip: {'ip': item.ip, 'port': item.port | string} } } }, recursive=True) }}"
+      when: item.port is defined
+      with_items: "{{ zone.primaries }}"
+
+    - name: Convert primaries without port
+      ansible.builtin.set_fact:
+        zone_auxiliary: "{{ zone_auxiliary | default({}) | combine( { zone.name: { 'primaries_dict': { item: {'ip': item} } } }, recursive=True) }}"
+      when: item.port is not defined
+      with_items: "{{ zone.primaries }}"
+
+- name: Build also_notify dict
+  when: zone.also_notify is defined
+  block:
+    - name: Convert also_notify with port
+      ansible.builtin.set_fact:
+        zone_auxiliary: "{{ zone_auxiliary | default({}) | combine( { zone.name: {'also_notify_dict': { item.ip: {'ip': item.ip, 'port': item.port | string} } } }, recursive=True) }}"
+      when: item.port is defined
+      with_items: "{{ zone.also_notify }}"
+
+    - name: Convert also_notify without port
+      ansible.builtin.set_fact:
+        zone_auxiliary: "{{ zone_auxiliary | default({}) | combine( { zone.name: { 'also_notify_dict': { item: {'ip': item} } } }, recursive=True) }}"
+      when: item.port is not defined
+      with_items: "{{ zone.also_notify }}"
+
+- name: Build zone forwarders dict
+  when: zone.forwarders is defined
+  block:
+    - name: Convert forwarders with port
+      ansible.builtin.set_fact:
+        zone_auxiliary: "{{ zone_auxiliary | default({}) | combine( { zone.name: {'forwarders_dict': { item.ip: {'ip': item.ip, 'port': item.port | string} } } }, recursive=True) }}"
+      when: item.port is defined
+      with_items: "{{ zone.forwarders }}"
+
+    - name: Convert forwarders without port
+      ansible.builtin.set_fact:
+        zone_auxiliary: "{{ zone_auxiliary | default({}) | combine({zone.name: {'forwarders_dict': {item: {'ip': item}}}}, recursive=True) }}"
+      when: item.port is not defined
+      with_items: "{{ zone.forwarders }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -104,9 +104,20 @@
   with_items: '{{ bind_zones }}'
   tags: bind
 
+- name: Build auxiliary zone dictionary (creates fact zone_auxiliary)
+  ansible.builtin.include_tasks: "build_host_dicts.yml"
+  loop: '{{ bind_zones }}'
+  loop_control:
+    loop_var: zone
+
+
 - name: Configure zones
   include_tasks: zones.yml
   tags: bind
+
+- name: Show templating results
+  ansible.builtin.debug:
+    msg: "{{ lookup('ansible.builtin.template', 'etc_named.conf.j2') }}"
 
 - name: Main BIND config file
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -110,14 +110,9 @@
   loop_control:
     loop_var: zone
 
-
 - name: Configure zones
   include_tasks: zones.yml
   tags: bind
-
-- name: Show templating results
-  ansible.builtin.debug:
-    msg: "{{ lookup('ansible.builtin.template', 'etc_named.conf.j2') }}"
 
 - name: Main BIND config file
   template:
@@ -148,4 +143,3 @@
     (ansible_facts.services[bind_service].state == "running") and (item.allow_update | default(false))
   with_items: '{{ bind_zones }}'
   tags: bind
-

--- a/tasks/zones.yml
+++ b/tasks/zones.yml
@@ -98,8 +98,8 @@
   when: >
     (item.create_forward_zones is not defined or item.create_forward_zones) and
     ((item.type is defined and item.type == 'primary') or
-    (item.type is not defined and item.primaries is defined and
-    (host_all_addresses | intersect(item.primaries) | length > 0)))
+    (item.type is not defined and zone_auxiliary[item.name]['primaries_dict'] is defined and
+    (host_all_addresses | intersect(zone_auxiliary[item.name]['primaries_dict'].keys()) | length > 0)))
   notify: reload bind
   tags: bind
 
@@ -123,8 +123,8 @@
   when: >
     (item.create_reverse_zones is not defined or item.create_reverse_zones) and
     ((item[0].type is defined and item[0].type == 'primary') or
-    (item[0].type is not defined and item[0].primaries is defined and
-    (host_all_addresses | intersect(item[0].primaries) | length > 0)))
+    (item[0].type is not defined and zone_auxiliary[item[0].name]['primaries_dict'] is defined and
+    (host_all_addresses | intersect(zone_auxiliary[item[0].name]['primaries_dict'].keys()) | length > 0)))
   notify: reload bind
   tags: bind
 
@@ -148,7 +148,7 @@
   when: >
     (item.create_reverse_zones is not defined or item.create_reverse_zones) and
     ((item[0].type is defined and item[0].type == 'primary') or
-    (item[0].type is not defined and item[0].primaries is defined and
-    (host_all_addresses | intersect(item[0].primaries) | length > 0)))
+    (item[0].type is not defined and zone_auxiliary[item[0].name]['primaries_dict'] is defined and
+    (host_all_addresses | intersect(zone_auxiliary[item[0].name]['primaries_dict'].keys()) | length > 0)))
   notify: reload bind
   tags: bind

--- a/templates/auth_transfer.j2
+++ b/templates/auth_transfer.j2
@@ -1,13 +1,14 @@
 // {{ ansible_managed }}
 {% if bind_key_mapping | length > 0 %}
 {% for primary in bind_key_mapping.keys() %}
-server {{ primary }} {
+server {{ primary | regex_replace('^(\\S*)( .*)?$', '\\1') }} {
   keys { {{ bind_key_mapping[primary] }}; };
 };
 {% endfor %}
 {% endif %}
-
-{% if not (ansible_default_ipv4.address in bind_key_mapping) %}
+{# Clean up bind key mapping #}
+{% set _cleaned_bind_key_mapping = bind_key_mapping.keys() | map('regex_replace', '^(\\S*)( .*)?$', '\\1') | list | zip(bind_key_mapping.keys()) | community.general.dict %}
+{% if not (ansible_default_ipv4.address in _cleaned_bind_key_mapping) %}
 server {{ ansible_default_ipv4.address }} {
   keys { {{ bind_dns_keys[0].name }}  };
 };

--- a/templates/auth_transfer.j2
+++ b/templates/auth_transfer.j2
@@ -1,14 +1,13 @@
 // {{ ansible_managed }}
 {% if bind_key_mapping | length > 0 %}
 {% for primary in bind_key_mapping.keys() %}
-server {{ primary | regex_replace('^(\\S*)( .*)?$', '\\1') }} {
+server {{ primary }} {
   keys { {{ bind_key_mapping[primary] }}; };
 };
 {% endfor %}
 {% endif %}
-{# Clean up bind key mapping #}
-{% set _cleaned_bind_key_mapping = bind_key_mapping.keys() | map('regex_replace', '^(\\S*)( .*)?$', '\\1') | list | zip(bind_key_mapping.keys()) | community.general.dict %}
-{% if not (ansible_default_ipv4.address in _cleaned_bind_key_mapping) %}
+
+{% if not (ansible_default_ipv4.address in bind_key_mapping) %}
 server {{ ansible_default_ipv4.address }} {
   keys { {{ bind_dns_keys[0].name }}  };
 };

--- a/templates/etc_named.conf.j2
+++ b/templates/etc_named.conf.j2
@@ -109,9 +109,38 @@ include "{{ file }}";
 {% endfor %}
 {% if bind_zones is defined %}
 {% for bind_zone in bind_zones %}
-{# Generate a dict of raw primary IP addresses to actual primary entries in the zone (that may be follow by e.g. a port specification) #}
-{% if bind_zone.primaries is defined %}
-{% set _cleaned_up_primaries = bind_zone.primaries | map('regex_replace', '^(\\S*)( .*)?$', '\\1') | list | zip(bind_zone.primaries) | community.general.dict %}
+{# Generate a list of primaries strings including additional properts (e.g. a port specification) #}
+{% if zone_auxiliary[bind_zone.name] is defined and zone_auxiliary[bind_zone.name]['primaries_dict'] is defined%}
+{% set _primaries = [] %}
+{% for primary in zone_auxiliary[bind_zone.name]['primaries_dict'].values() %}
+{% set primary_string = primary.ip %}
+{% if primary.port is defined %}
+{% set primary_string = primary_string + ' port ' + primary.port | string %}
+{% endif %}
+{% set dummy = _primaries.append(primary_string) %}
+{% endfor %}
+{% endif %}
+{# Build forwarders #}
+{% if zone_auxiliary[bind_zone.name] is defined and zone_auxiliary[bind_zone.name]['forwarders_dict'] is defined%}
+{% set _forwarders = [] %}
+{% for forwarder in zone_auxiliary[bind_zone.name]['forwarders_dict'].values() %}
+{% set forwarder_string = forwarder.ip %}
+{% if forwarder.port is defined %}
+{% set forwarder_string = forwarder_string + ' port ' + forwarder.port | string %}
+{% endif %}
+{% set dummy = _forwarders.append(forwarder_string) %}
+{% endfor %}
+{% endif %}
+{# Build also-notify #}
+{% if zone_auxiliary[bind_zone.name] is defined and zone_auxiliary[bind_zone.name]['also_notify_dict'] is defined%}
+{% set _also_notify = [] %}
+{% for also_notify in zone_auxiliary[bind_zone.name]['also_notify_dict'].values() %}
+{% set also_notify_string = also_notify.ip %}
+{% if also_notify.port is defined %}
+{% set also_notify_string = also_notify_string + ' port ' + also_notify.port | string %}
+{% endif %}
+{% set dummy = _also_notify.append(also_notify_string) %}
+{% endfor %}
 {% endif %}
 {% if bind_zone.create_forward_zones is not defined or bind_zone.create_forward_zones %}
 {# Start: set zone type  #}
@@ -121,9 +150,9 @@ include "{{ file }}";
 {% set _type = 'secondary' %}
 {% elif bind_zone.type is defined and bind_zone.type == 'forward' %}
 {% set _type = 'forward' %}
-{% elif bind_zone.type is not defined and bind_zone.primaries is defined and (host_all_addresses|intersect(_cleaned_up_primaries)|length > 0) %}
+{% elif bind_zone.type is not defined and bind_zone.primaries is defined and (host_all_addresses|intersect(zone_auxiliary[bind_zone.name]['primaries_dict'])|length > 0) %}
 {% set _type = 'primary' %}
-{% elif bind_zone.type is not defined and bind_zone.primaries is defined and not (host_all_addresses|intersect(_cleaned_up_primaries)|length > 0) %}
+{% elif bind_zone.type is not defined and bind_zone.primaries is defined and not (host_all_addresses|intersect(zone_auxiliary[bind_zone.name]['primaries_dict'])|length > 0) %}
 {% set _type = 'secondary' %}
 {% elif bind_zone.type is not defined and bind_zone.forwarders is defined %}
 {% set _type = 'forward' %}
@@ -132,7 +161,7 @@ include "{{ file }}";
 
 {# Start: set mapped primaries for the zone #}
 {% if bind_key_mapping | length != 0 %}
-{% set _mapped_zone_primaries = _cleaned_up_primaries | dict2items | selectattr('value', 'in', bind_key_mapping.keys()) | items2dict %}
+{% set _mapped_zone_primaries = bind_key_mapping.keys() | intersect(zone_auxiliary[bind_zone.name]['primaries_dict']) %}
 {% else %}
 {% set _mapped_zone_primaries = [] %}
 {% endif %}
@@ -140,7 +169,7 @@ include "{{ file }}";
 {# {{ _mapped_zone_primaries }} #}
 zone "{{ bind_zone.name }}" IN {
 {% if _type == 'primary' %}
-  type master;
+  type primary;
   file "{{ bind_zone_dir }}/{{ bind_zone.name }}";
 {% if bind_acls | length == 0 and bind_key_mapping | length == 0 %}
   notify yes;
@@ -154,16 +183,16 @@ zone "{{ bind_zone.name }}" IN {
 {% endfor %}
 {% endif %}
 {% for primary in host_all_addresses | intersect(_mapped_zone_primaries) %}
-    key {{ bind_key_mapping[_cleaned_up_primaries[primary]] }};
+    key {{ bind_key_mapping[primary] }};
 {% endfor %}
   };
 {% endif %}
 {% if bind_zone.also_notify is defined %}
   also-notify {
-{% for secondary in bind_zone.also_notify %}
+{% for secondary in _also_notify %}
 {% if host_all_addresses | intersect(_mapped_zone_primaries) | length != 0 %}
 {% for primary in host_all_addresses | intersect(_mapped_zone_primaries) %}
-    {{ secondary }} key {{ bind_key_mapping[_cleaned_up_primaries[primary]] }};
+    {{ secondary }} key {{ bind_key_mapping[primary] }};
 {% endfor %}
 {% else %}
     {{ secondary }};
@@ -177,14 +206,14 @@ zone "{{ bind_zone.name }}" IN {
   allow-update { none; };
 {% endif %}
 {% elif _type == 'secondary' %}
-  type slave;
+  type secondary;
   notify explicit;
-  masters { {{ bind_zone.primaries|join('; ') }}; };
+  primaries { {{ _primaries | join('; ') }}; };
   file "{{ bind_secondary_dir }}/{{ bind_zone.name }}";
 {% elif _type == 'forward' %}
   type forward;
   forward only;
-  forwarders { {{ bind_zone.forwarders|join('; ') }}; };
+  forwarders { {{ _forwarders | join('; ') }}; };
 {% endif %}
 };
 {% endif %}
@@ -194,7 +223,7 @@ zone "{{ bind_zone.name }}" IN {
 
 zone "{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr.arpa" IN {
 {% if _type == 'primary' %}
-  type master;
+  type primary;
   file "{{ bind_zone_dir }}/{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr.arpa";
 {% if bind_acls | length == 0 and bind_key_mapping | length == 0 %}
   notify yes;
@@ -208,16 +237,16 @@ zone "{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr
 {% endfor %}
 {% endif %}
 {% for primary in host_all_addresses | intersect(_mapped_zone_primaries) %}
-    key {{ bind_key_mapping[_cleaned_up_primaries[primary]] }};
+    key {{ bind_key_mapping[primary] }};
 {% endfor %}
   };
 {% endif %}
 {% if bind_zone.also_notify is defined %}
   also-notify {
-{% for secondary in bind_zone.also_notify %}
+{% for secondary in _also_notify %}
 {% if host_all_addresses | intersect(_mapped_zone_primaries) | length != 0 %}
 {% for primary in host_all_addresses | intersect(_mapped_zone_primaries) %}
-    {{ secondary }} key {{ bind_key_mapping[_cleaned_up_primaries[primary]] }};
+    {{ secondary }} key {{ bind_key_mapping[primary] }};
 {% endfor %}
 {% else %}
     {{ secondary }};
@@ -231,13 +260,13 @@ zone "{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr
   allow-update { none; };
 {% endif %}
 {% elif _type == 'secondary' %}
-  type slave;
-  masters { {{ bind_zone.primaries|join('; ') }}; };
+  type secondary;
+  primaries { {{ _primaries | join('; ') }}; };
   file "{{ bind_secondary_dir }}/{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr.arpa";
 {% elif _type == 'forward' %}
   type forward;
   forward only;
-  forwarders { {{ bind_zone.forwarders|join('; ') }}; };
+  forwarders { {{ _forwarders | join('; ') }}; };
 {% endif %}
 };
 {% endfor %}
@@ -249,7 +278,7 @@ zone "{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr
 
 zone "{{ (network | ansible.utils.ipaddr('revdns'))[-(9+(network|regex_replace('^.*/','')|int)//2):] }}" IN {
 {% if _type == 'primary' %}
-  type master;
+  type primary;
   file "{{ bind_zone_dir }}/{{ (network | ansible.utils.ipaddr('revdns'))[-(9+(network|regex_replace('^.*/','')|int)//2):-1] }}";
 {% if bind_acls | length == 0 and bind_key_mapping | length == 0 %}
   notify yes;
@@ -263,16 +292,16 @@ zone "{{ (network | ansible.utils.ipaddr('revdns'))[-(9+(network|regex_replace('
 {% endfor %}
 {% endif %}
 {% for primary in host_all_addresses | intersect(_mapped_zone_primaries) %}
-    key {{ bind_key_mapping[_cleaned_up_primaries[primary]] }};
+    key {{ bind_key_mapping[primary] }};
 {% endfor %}
   };
 {% endif %}
 {% if bind_zone.also_notify is defined %}
   also-notify {
-{% for secondary in bind_zone.also_notify %}
+{% for secondary in _also_notify %}
 {% if host_all_addresses | intersect(_mapped_zone_primaries) | length != 0 %}
 {% for primary in host_all_addresses | intersect(_mapped_zone_primaries) %}
-    {{ secondary }} key {{ bind_key_mapping[_cleaned_up_primaries[primary]] }};
+    {{ secondary }} key {{ bind_key_mapping[primary] }};
 {% endfor %}
 {% else %}
     {{ secondary }};
@@ -286,13 +315,13 @@ zone "{{ (network | ansible.utils.ipaddr('revdns'))[-(9+(network|regex_replace('
   allow-update { none; };
 {% endif %}
 {% elif _type == 'secondary' %}
-  type slave;
-  masters { {{ bind_zone.primaries|join('; ') }}; };
+  type secondary;
+  primaries { {{ _primaries | join('; ') }}; };
   file "{{ bind_secondary_dir }}/{{ (network | ansible.utils.ipaddr('revdns'))[-(9+(network|regex_replace('^.*/','')|int)//2):-1] }}";
 {% elif _type == 'forward' %}
   type forward;
   forward only;
-  forwarders { {{ bind_zone.forwarders|join('; ') }}; };
+  forwarders { {{ _forwarders | join('; ') }}; };
 {% endif %}
 };
 {% endfor %}

--- a/templates/etc_named.conf.j2
+++ b/templates/etc_named.conf.j2
@@ -109,7 +109,10 @@ include "{{ file }}";
 {% endfor %}
 {% if bind_zones is defined %}
 {% for bind_zone in bind_zones %}
-
+{# Generate a dict of raw primary IP addresses to actual primary entries in the zone (that may be follow by e.g. a port specification) #}
+{% if bind_zone.primaries is defined %}
+{% set _cleaned_up_primaries = bind_zone.primaries | map('regex_replace', '^(\\S*)( .*)?$', '\\1') | list | zip(bind_zone.primaries) | community.general.dict %}
+{% endif %}
 {% if bind_zone.create_forward_zones is not defined or bind_zone.create_forward_zones %}
 {# Start: set zone type  #}
 {% if bind_zone.type is defined and bind_zone.type == 'primary' %}
@@ -118,9 +121,9 @@ include "{{ file }}";
 {% set _type = 'secondary' %}
 {% elif bind_zone.type is defined and bind_zone.type == 'forward' %}
 {% set _type = 'forward' %}
-{% elif bind_zone.type is not defined and bind_zone.primaries is defined and (host_all_addresses|intersect(bind_zone.primaries)|length > 0) %}
+{% elif bind_zone.type is not defined and bind_zone.primaries is defined and (host_all_addresses|intersect(_cleaned_up_primaries)|length > 0) %}
 {% set _type = 'primary' %}
-{% elif bind_zone.type is not defined and bind_zone.primaries is defined and not (host_all_addresses|intersect(bind_zone.primaries)|length > 0) %}
+{% elif bind_zone.type is not defined and bind_zone.primaries is defined and not (host_all_addresses|intersect(_cleaned_up_primaries)|length > 0) %}
 {% set _type = 'secondary' %}
 {% elif bind_zone.type is not defined and bind_zone.forwarders is defined %}
 {% set _type = 'forward' %}
@@ -129,12 +132,12 @@ include "{{ file }}";
 
 {# Start: set mapped primaries for the zone #}
 {% if bind_key_mapping | length != 0 %}
-{% set _mapped_zone_primaries = bind_key_mapping.keys() | intersect(bind_zone.primaries) %}
+{% set _mapped_zone_primaries = _cleaned_up_primaries | dict2items | selectattr('value', 'in', bind_key_mapping.keys()) | items2dict %}
 {% else %}
 {% set _mapped_zone_primaries = [] %}
 {% endif %}
 {# End: set mapped primaries for the zone #}
-
+{# {{ _mapped_zone_primaries }} #}
 zone "{{ bind_zone.name }}" IN {
 {% if _type == 'primary' %}
   type master;
@@ -151,7 +154,7 @@ zone "{{ bind_zone.name }}" IN {
 {% endfor %}
 {% endif %}
 {% for primary in host_all_addresses | intersect(_mapped_zone_primaries) %}
-    key {{ bind_key_mapping[primary] }};
+    key {{ bind_key_mapping[_cleaned_up_primaries[primary]] }};
 {% endfor %}
   };
 {% endif %}
@@ -160,7 +163,7 @@ zone "{{ bind_zone.name }}" IN {
 {% for secondary in bind_zone.also_notify %}
 {% if host_all_addresses | intersect(_mapped_zone_primaries) | length != 0 %}
 {% for primary in host_all_addresses | intersect(_mapped_zone_primaries) %}
-    {{ secondary }} key {{ bind_key_mapping[primary] }};
+    {{ secondary }} key {{ bind_key_mapping[_cleaned_up_primaries[primary]] }};
 {% endfor %}
 {% else %}
     {{ secondary }};
@@ -205,7 +208,7 @@ zone "{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr
 {% endfor %}
 {% endif %}
 {% for primary in host_all_addresses | intersect(_mapped_zone_primaries) %}
-    key {{ bind_key_mapping[primary] }};
+    key {{ bind_key_mapping[_cleaned_up_primaries[primary]] }};
 {% endfor %}
   };
 {% endif %}
@@ -214,7 +217,7 @@ zone "{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr
 {% for secondary in bind_zone.also_notify %}
 {% if host_all_addresses | intersect(_mapped_zone_primaries) | length != 0 %}
 {% for primary in host_all_addresses | intersect(_mapped_zone_primaries) %}
-    {{ secondary }} key {{ bind_key_mapping[primary] }};
+    {{ secondary }} key {{ bind_key_mapping[_cleaned_up_primaries[primary]] }};
 {% endfor %}
 {% else %}
     {{ secondary }};
@@ -260,7 +263,7 @@ zone "{{ (network | ansible.utils.ipaddr('revdns'))[-(9+(network|regex_replace('
 {% endfor %}
 {% endif %}
 {% for primary in host_all_addresses | intersect(_mapped_zone_primaries) %}
-    key {{ bind_key_mapping[primary] }};
+    key {{ bind_key_mapping[_cleaned_up_primaries[primary]] }};
 {% endfor %}
   };
 {% endif %}
@@ -269,7 +272,7 @@ zone "{{ (network | ansible.utils.ipaddr('revdns'))[-(9+(network|regex_replace('
 {% for secondary in bind_zone.also_notify %}
 {% if host_all_addresses | intersect(_mapped_zone_primaries) | length != 0 %}
 {% for primary in host_all_addresses | intersect(_mapped_zone_primaries) %}
-    {{ secondary }} key {{ bind_key_mapping[primary] }};
+    {{ secondary }} key {{ bind_key_mapping[_cleaned_up_primaries[primary]] }};
 {% endfor %}
 {% else %}
     {{ secondary }};

--- a/templates/etc_named.conf.j2
+++ b/templates/etc_named.conf.j2
@@ -208,7 +208,7 @@ zone "{{ bind_zone.name }}" IN {
 {% elif _type == 'secondary' %}
   type slave;
   notify explicit;
-  primaries { {{ _primaries | join('; ') }}; };
+  masters { {{ _primaries | join('; ') }}; };
   file "{{ bind_secondary_dir }}/{{ bind_zone.name }}";
 {% elif _type == 'forward' %}
   type forward;
@@ -261,7 +261,7 @@ zone "{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr
 {% endif %}
 {% elif _type == 'secondary' %}
   type slave;
-  primaries { {{ _primaries | join('; ') }}; };
+  masters { {{ _primaries | join('; ') }}; };
   file "{{ bind_secondary_dir }}/{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr.arpa";
 {% elif _type == 'forward' %}
   type forward;
@@ -316,7 +316,7 @@ zone "{{ (network | ansible.utils.ipaddr('revdns'))[-(9+(network|regex_replace('
 {% endif %}
 {% elif _type == 'secondary' %}
   type slave;
-  primaries { {{ _primaries | join('; ') }}; };
+  masters { {{ _primaries | join('; ') }}; };
   file "{{ bind_secondary_dir }}/{{ (network | ansible.utils.ipaddr('revdns'))[-(9+(network|regex_replace('^.*/','')|int)//2):-1] }}";
 {% elif _type == 'forward' %}
   type forward;

--- a/templates/etc_named.conf.j2
+++ b/templates/etc_named.conf.j2
@@ -169,7 +169,7 @@ include "{{ file }}";
 {# {{ _mapped_zone_primaries }} #}
 zone "{{ bind_zone.name }}" IN {
 {% if _type == 'primary' %}
-  type primary;
+  type master;
   file "{{ bind_zone_dir }}/{{ bind_zone.name }}";
 {% if bind_acls | length == 0 and bind_key_mapping | length == 0 %}
   notify yes;
@@ -206,7 +206,7 @@ zone "{{ bind_zone.name }}" IN {
   allow-update { none; };
 {% endif %}
 {% elif _type == 'secondary' %}
-  type secondary;
+  type slave;
   notify explicit;
   primaries { {{ _primaries | join('; ') }}; };
   file "{{ bind_secondary_dir }}/{{ bind_zone.name }}";
@@ -223,7 +223,7 @@ zone "{{ bind_zone.name }}" IN {
 
 zone "{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr.arpa" IN {
 {% if _type == 'primary' %}
-  type primary;
+  type master;
   file "{{ bind_zone_dir }}/{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr.arpa";
 {% if bind_acls | length == 0 and bind_key_mapping | length == 0 %}
   notify yes;
@@ -260,7 +260,7 @@ zone "{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr
   allow-update { none; };
 {% endif %}
 {% elif _type == 'secondary' %}
-  type secondary;
+  type slave;
   primaries { {{ _primaries | join('; ') }}; };
   file "{{ bind_secondary_dir }}/{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr.arpa";
 {% elif _type == 'forward' %}
@@ -278,7 +278,7 @@ zone "{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr
 
 zone "{{ (network | ansible.utils.ipaddr('revdns'))[-(9+(network|regex_replace('^.*/','')|int)//2):] }}" IN {
 {% if _type == 'primary' %}
-  type primary;
+  type master;
   file "{{ bind_zone_dir }}/{{ (network | ansible.utils.ipaddr('revdns'))[-(9+(network|regex_replace('^.*/','')|int)//2):-1] }}";
 {% if bind_acls | length == 0 and bind_key_mapping | length == 0 %}
   notify yes;
@@ -315,7 +315,7 @@ zone "{{ (network | ansible.utils.ipaddr('revdns'))[-(9+(network|regex_replace('
   allow-update { none; };
 {% endif %}
 {% elif _type == 'secondary' %}
-  type secondary;
+  type slave;
   primaries { {{ _primaries | join('; ') }}; };
   file "{{ bind_secondary_dir }}/{{ (network | ansible.utils.ipaddr('revdns'))[-(9+(network|regex_replace('^.*/','')|int)//2):-1] }}";
 {% elif _type == 'forward' %}


### PR DESCRIPTION
Allow specifying either plain IP address or dictionary with keys `ip` and `port` for:
  - zone primaries
  - zone forwarders
  - zone also-notify servers