### PR TITLE
Feat/bind manage service

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The packages `python-netaddr` (required for the [`ansible.utils.ipaddr`](https:/
 
 | Variable                    | Default              | Comments (type)                                                                                                                      |
 | :-------------------------- | :------------------- | :----------------------------------------------------------------------------------------------------------------------------------- |
+| `bind_manage_service`       | `true`               | Indicating whether to install, start and enable bind. If set to `false`, only the configuration is generated (but not verified).     |
 | `bind_acls`                 | `[]`                 | A list of ACL definitions, which are mappings with keys `name:` and `match_list:`. See below for an example.                         |
 | `bind_allow_query`          | `['localhost']`      | A list of hosts that are allowed to query this DNS server. Set to ['any'] to allow all hosts                                         |
 | `bind_allow_recursion`      | `['any']`            | Similar to `bind_allow_query`, this option applies to recursive queries.                                                             |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -97,3 +97,6 @@ bind_log: "data/named.run"
 
 # Global option max-cache-size
 bind_max_cache_size: ""
+
+# Flag indicating whether to start / reload BIND (if false, only the configuration will be created/updated)
+bind_manage_service: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,3 +5,4 @@
     name: "{{ bind_service }}"
     state: reloaded
   become: true
+  when: bind_manage_service

--- a/molecule/config_only/converge.yml
+++ b/molecule/config_only/converge.yml
@@ -1,0 +1,9 @@
+---
+
+# Remark that common variables are defined in `group_vars/all.yml`
+
+- name: Primary/Secondary with Shared Inventory
+  hosts: dns
+
+  roles:
+    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule/config_only/group_vars/all.yml
+++ b/molecule/config_only/group_vars/all.yml
@@ -1,0 +1,125 @@
+---
+bind_statistics_channels: true
+bind_statistics_allow:
+  - any
+bind_zone_dir: /var/local/named-zones
+bind_zone_file_mode: '0660'
+bind_allow_query:
+  - any
+bind_listen_ipv4:
+  - any
+bind_listen_ipv6:
+  - any
+bind_listen_ipv4_port:
+  - 53
+bind_listen_ipv6_port:
+  - 53
+bind_acls:
+  - name: acl1
+    match_list:
+      - 10.11.0/16
+bind_forwarders:
+  - '8.8.8.8'
+  - '8.8.4.4'
+bind_recursion: true
+bind_dns64: true
+bind_query_log: 'data/query.log'
+bind_check_names: 'master ignore'
+bind_zone_minimum_ttl: "2D"
+bind_zone_ttl: "2W"
+bind_zone_time_to_refresh: "2D"
+bind_zone_time_to_retry: "2H"
+bind_zone_time_to_expire: "2W"
+bind_manage_service: false
+bind_zones:
+  - name: 'example.com'
+    primaries:
+      - 10.11.0.4
+    networks:
+      - '192.0.2'
+    ipv6_networks:
+      - '2001:db9::/48'
+    name_servers:
+      - ns1.acme-inc.com.
+      - ns2.acme-inc.com.
+    hostmaster_email: admin
+    hosts:
+      - name: srv001
+        ip: 192.0.2.1
+        ipv6: '2001:db9::1'
+        aliases:
+          - www
+      - name: srv002
+        ip: 192.0.2.2
+        ipv6: '2001:db9::2'
+      - name: mail001
+        ip: 192.0.2.10
+        ipv6: '2001:db9::3'
+    mail_servers:
+      - name: mail001
+        preference: 10
+  - name: 'acme-inc.com'
+    primaries:
+      - 10.11.0.4
+    networks:
+      - '10.11'
+    ipv6_networks:
+      - '2001:db8::/48'
+    name_servers:
+      - ns1
+      - ns2
+    also_notify:
+      - 10.11.0.5
+    hosts:
+      - name: ns1
+        ip: 10.11.0.4
+      - name: ns2
+        ip: 10.11.0.5
+      - name: srv001
+        ip: 10.11.1.1
+        ipv6: 2001:db8::1
+        aliases:
+          - www
+      - name: srv002
+        ip: 10.11.1.2
+        ipv6: 2001:db8::2
+        aliases:
+          - mysql
+      - name: mail001
+        ip: 10.11.2.1
+        ipv6: 2001:db8::d:1
+        aliases:
+          - smtp
+          - mail-in
+      - name: mail002
+        ip: 10.11.2.2
+        ipv6: 2001:db8::d:2
+      - name: mail003
+        ip: 10.11.2.3
+        ipv6: 2001:db8::d:3
+        aliases:
+          - imap
+          - mail-out
+      - name: srv010
+        ip: 10.11.0.10
+      - name: srv011
+        ip: 10.11.0.11
+      - name: srv012
+        ip: 10.11.0.12
+    mail_servers:
+      - name: mail001
+        preference: 10
+      - name: mail002
+        preference: 20
+    services:
+      - name: _ldap._tcp
+        weight: 100
+        port: 88
+        target: srv010
+    text:
+      - name: _kerberos
+        text: KERBEROS.ACME-INC.COM
+      - name: '@'
+        text:
+          - 'some text'
+          - 'more text'

--- a/molecule/config_only/molecule.yml
+++ b/molecule/config_only/molecule.yml
@@ -1,0 +1,72 @@
+---
+dependency:
+  name: galaxy
+
+driver:
+  # Specifies the driver that should be used. Podman should also work
+  name: docker
+
+lint: |
+  set -e
+  yamllint .
+  ansible-lint -x 106 .
+
+platforms:
+  # Set name and hostname
+  - name: ns4
+    groups:
+      - dns
+    hostname: ns4
+    docker_networks:
+      - name: bind
+        ipam_config:
+          - subnet: "10.11.0.0/16"
+            gateway: "10.11.0.254"
+    networks:
+      - name: bind
+        ipv4_address: "10.11.0.4"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - ${PWD}:/etc/ansible/roles/bertvv.bind:ro
+      - ${PWD}/library:/root/.ansible/plugins/modules:ro
+    privileged: true
+    cgroupns_mode: host
+    pre_build_image: true
+    tty: true
+    environment:
+      container: docker
+
+  - name: ns5
+    hostname: ns5
+    groups:
+      - dns
+    networks:
+      - name: bind
+        ipv4_address: "10.11.0.5"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian10}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - ${PWD}:/etc/ansible/roles/bertvv.bind:ro
+      - ${PWD}/library:/root/.ansible/plugins/modules:ro
+    privileged: true
+    cgroupns_mode: host
+    pre_build_image: true
+    tty: true
+    environment:
+      container: docker
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_legacy_silent
+      callback_whitelist: profile_tasks
+    ssh_connection:
+      pipelining: true
+
+# Runs the verify.yml playbook
+verifier:
+  name: ansible

--- a/molecule/config_only/verify.yml
+++ b/molecule/config_only/verify.yml
@@ -14,12 +14,12 @@
       ansible.builtin.include_vars: "{{ item }}"
       with_first_found:
         - files:
-          - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
-          - "{{ ansible_distribution }}.yml"
-          - "{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
-          - "{{ ansible_os_family }}.yml"
-          - "{{ ansible_distribution_file_variety }}-{{ ansible_distribution_major_version }}.yml"
-          - "{{ ansible_distribution_file_variety }}.yml"
+            - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
+            - "{{ ansible_distribution }}.yml"
+            - "{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
+            - "{{ ansible_os_family }}.yml"
+            - "{{ ansible_distribution_file_variety }}-{{ ansible_distribution_major_version }}.yml"
+            - "{{ ansible_distribution_file_variety }}.yml"
           paths:
             - "../../vars"
 

--- a/molecule/config_only/verify.yml
+++ b/molecule/config_only/verify.yml
@@ -1,0 +1,96 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: true
+
+  tasks:
+    - name: Include role variables
+      ansible.builtin.include_vars: "../../defaults/main.yml"
+
+    - name: Include group variables
+      ansible.builtin.include_vars: "group_vars/all.yml"
+
+    - name: Source specific variables
+      ansible.builtin.include_vars: "{{ item }}"
+      with_first_found:
+        - files:
+          - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
+          - "{{ ansible_distribution }}.yml"
+          - "{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
+          - "{{ ansible_os_family }}.yml"
+          - "{{ ansible_distribution_file_variety }}-{{ ansible_distribution_major_version }}.yml"
+          - "{{ ansible_distribution_file_variety }}.yml"
+          paths:
+            - "../../vars"
+
+    - name: Gather Package Facts
+      ansible.builtin.package_facts:
+
+    - name: Verify BIND packages are not installed
+      ansible.builtin.assert:
+        that: ansible_facts.packages[item] is not defined
+      with_items: "{{ bind_packages }}"
+
+    - name: Checking whether bind_conf_dir exists
+      ansible.builtin.stat:
+        path: "{{ bind_conf_dir }}"
+      register: bind_conf_dir_check
+
+    - name: Checking whether bind_config exists
+      ansible.builtin.stat:
+        path: "{{ bind_config }}"
+      register: bind_config_check
+
+    - name: Verify bind config folder and file existence
+      ansible.builtin.assert:
+        that:
+          - bind_conf_dir_check.stat is defined
+          - bind_conf_dir_check.stat.isdir
+          - bind_config_check.stat is defined
+          - not bind_config_check.stat.isdir
+
+    - debug:
+        var: ansible_all_ipv4_addresses
+
+    - debug:
+        var: item.primaries
+      with_items: "{{ bind_zones }}"
+    - name: Detect whether host is a primary
+      ansible.builtin.set_fact:
+        is_primary: true
+      when:
+        - item.primaries | intersect(ansible_all_ipv4_addresses) | length > 0
+        - is_primary is not defined
+      with_items: "{{ bind_zones }}"
+
+    - name: Detect whether host is a secondary
+      ansible.builtin.set_fact:
+        is_secondary: true
+      when:
+        - item.primaries | intersect(ansible_all_ipv4_addresses) | length == 0
+        - is_secondary is not defined
+      with_items: "{{ bind_zones }}"
+
+    - name: Checking that config file contains primary type
+      ansible.builtin.lineinfile:
+        path: "{{ bind_config }}"
+        line: "  type master;"
+        state: present
+      check_mode: true
+      register: is_primary_config_present
+      failed_when: is_primary_config_present is changed or is_primary_config_present is failed
+      when:
+        - is_primary is defined
+        - is_primary
+
+    - name: Checking that config file contains secondary type
+      ansible.builtin.lineinfile:
+        path: "{{ bind_config }}"
+        line: "  type slave;"
+        state: present
+      check_mode: true
+      register: is_secondary_config_present
+      failed_when: is_secondary_config_present is changed or is_secondary_config_present is failed
+      when:
+        - is_secondary is defined
+        - is_secondary

--- a/molecule/config_only/verify.yml
+++ b/molecule/config_only/verify.yml
@@ -49,11 +49,6 @@
           - bind_config_check.stat is defined
           - not bind_config_check.stat.isdir
 
-    - debug:
-        var: ansible_all_ipv4_addresses
-
-    - debug:
-        var: item.primaries
       with_items: "{{ bind_zones }}"
     - name: Detect whether host is a primary
       ansible.builtin.set_fact:

--- a/tasks/build_host_dicts.yml
+++ b/tasks/build_host_dicts.yml
@@ -4,13 +4,13 @@
   block:
     - name: Convert primaries with port
       ansible.builtin.set_fact:
-        zone_auxiliary: "{{ zone_auxiliary | default({}) | combine({zone.name: {'primaries_dict': {item.ip: {'ip': item.ip, 'port': item.port | string}}}}, recursive=True) }}"
-      when: item.port is defined
+        bind_zone_auxiliary: "{{ bind_zone_auxiliary | default({}) | combine({zone.name: {'primaries_dict': {item.ip: {'ip': item.ip, 'port': item.port | string}}}}, recursive=True) }}"
+      when: item.ip is defined
       with_items: "{{ zone.primaries }}"
 
     - name: Convert primaries without port
       ansible.builtin.set_fact:
-        zone_auxiliary: "{{ zone_auxiliary | default({}) | combine({zone.name: {'primaries_dict': {item: {'ip': item}}}}, recursive=True) }}"
+        bind_zone_auxiliary: "{{ bind_zone_auxiliary | default({}) | combine({zone.name: {'primaries_dict': {item: {'ip': item}}}}, recursive=True) }}"
       when: item.port is not defined
       with_items: "{{ zone.primaries }}"
 
@@ -19,13 +19,13 @@
   block:
     - name: Convert also_notify with port
       ansible.builtin.set_fact:
-        zone_auxiliary: "{{ zone_auxiliary | default({}) | combine({zone.name: {'also_notify_dict': {item.ip: {'ip': item.ip, 'port': item.port | string}}}}, recursive=True) }}"
+        bind_zone_auxiliary: "{{ bind_zone_auxiliary | default({}) | combine({zone.name: {'also_notify_dict': {item.ip: {'ip': item.ip, 'port': item.port | string}}}}, recursive=True) }}"
       when: item.port is defined
       with_items: "{{ zone.also_notify }}"
 
     - name: Convert also_notify without port
       ansible.builtin.set_fact:
-        zone_auxiliary: "{{ zone_auxiliary | default({}) | combine({zone.name: {'also_notify_dict': {item: {'ip': item}}}}, recursive=True) }}"
+        bind_zone_auxiliary: "{{ bind_zone_auxiliary | default({}) | combine({zone.name: {'also_notify_dict': {item: {'ip': item}}}}, recursive=True) }}"
       when: item.port is not defined
       with_items: "{{ zone.also_notify }}"
 
@@ -34,12 +34,12 @@
   block:
     - name: Convert forwarders with port
       ansible.builtin.set_fact:
-        zone_auxiliary: "{{ zone_auxiliary | default({}) | combine({zone.name: {'forwarders_dict': {item.ip: {'ip': item.ip, 'port': item.port | string}}}}, recursive=True) }}"
+        bind_zone_auxiliary: "{{ bind_zone_auxiliary | default({}) | combine({zone.name: {'forwarders_dict': {item.ip: {'ip': item.ip, 'port': item.port | string}}}}, recursive=True) }}"
       when: item.port is defined
       with_items: "{{ zone.forwarders }}"
 
     - name: Convert forwarders without port
       ansible.builtin.set_fact:
-        zone_auxiliary: "{{ zone_auxiliary | default({}) | combine({zone.name: {'forwarders_dict': {item: {'ip': item}}}}, recursive=True) }}"
+        bind_zone_auxiliary: "{{ bind_zone_auxiliary | default({}) | combine({zone.name: {'forwarders_dict': {item: {'ip': item}}}}, recursive=True) }}"
       when: item.port is not defined
       with_items: "{{ zone.forwarders }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,6 +59,7 @@
   ansible.builtin.user:
     name: "{{ bind_owner }}"
     group: "{{ bind_group }}"
+    create_home: false
     state: present
   when: not bind_manage_service
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,9 @@
     update_cache: true
   become: true
   changed_when: false
-  when: ansible_os_family == 'Debian'
+  when:
+    - bind_manage_service
+    - ansible_os_family == 'Debian'
   tags: bind
 
 - name: Assert that all XFR keys exist in the key list
@@ -42,9 +44,23 @@
     pkg: "{{ item }}"
     state: present
   become: true
+  when: bind_manage_service
   with_items:
     - "{{ bind_packages }}"
   tags: bind
+
+- name: Ensure bind_group exists
+  ansible.builtin.group:
+    name: "{{ bind_group }}"
+    state: present
+  when: not bind_manage_service
+
+- name: Ensure bind_owner exists
+  ansible.builtin.user:
+    name: "{{ bind_owner }}"
+    group: "{{ bind_group }}"
+    state: present
+  when: not bind_manage_service
 
 - name: Ensure runtime directories referenced in config exist
   ansible.builtin.file:
@@ -103,7 +119,11 @@
     host_all_addresses: "{{ [ipify_public_ip] | union(ansible_all_ipv4_addresses | union(ansible_all_ipv6_addresses)) }}"
   tags: bind
 
-- name: Build auxiliary zone dictionary (creates fact zone_auxiliary)
+- name: Initialize bind_zone_auxiliary
+  ansible.builtin.set_fact:
+    bind_zone_auxiliary: {}
+
+- name: Build auxiliary zone dictionary (creates fact bind_zone_auxiliary)
   ansible.builtin.include_tasks: "build_host_dicts.yml"
   loop: '{{ bind_zones }}'
   loop_control:
@@ -116,10 +136,11 @@
   failed_when: false
   changed_when: false
   when: >-
-    ((item.type is defined and item.type == 'primary') or
-    (item.type is not defined and zone_auxiliary[item.name]['primaries_dict'] is defined and
-    (host_all_addresses | intersect(zone_auxiliary[item.name]['primaries_dict'].keys()) | length > 0))) and
-    (ansible_facts.services[bind_service].state == "running") and (item.allow_update | default(false))
+    bind_manage_service and
+    (((item.type is defined and item.type == 'primary') or
+    (item.type is not defined and bind_zone_auxiliary[item.name]['primaries_dict'] is defined and
+    (host_all_addresses | intersect(bind_zone_auxiliary[item.name]['primaries_dict'].keys()) | length > 0))) and
+    (ansible_facts.services[bind_service].state == "running") and (item.allow_update | default(false)))
   with_items: '{{ bind_zones }}'
   tags: bind
 
@@ -140,7 +161,23 @@
   ansible.builtin.include_tasks: "zones.yml"
   tags: bind
 
-- name: Main BIND config file
+- name: Check if named-checkconf is available
+  ansible.builtin.command:
+    which named-checkconf
+  register: check_named
+  failed_when: check_named.rc not in [0,1]
+  changed_when: false
+
+- name: Ensure bind_conf_dir exists
+  ansible.builtin.file:
+    path: "{{ bind_conf_dir }}"
+    owner: "root"
+    group: "{{ bind_group }}"
+    mode: "02745"
+    state: directory
+  when: not bind_manage_service
+
+- name: Main BIND config file (with validation)
   ansible.builtin.template:
     src: etc_named.conf.j2
     dest: "{{ bind_config }}"
@@ -151,6 +188,20 @@
     validate: 'named-checkconf %s'
   become: true
   notify: Reload bind
+  when: check_named.rc == 0
+  tags: bind
+
+- name: Main BIND config file (without validation)
+  ansible.builtin.template:
+    src: etc_named.conf.j2
+    dest: "{{ bind_config }}"
+    owner: "{{ bind_owner }}"
+    group: "{{ bind_group }}"
+    mode: "0640"
+    setype: named_conf_t
+  become: true
+  notify: Reload bind
+  when: check_named.rc != 0
   tags: bind
 
 - name: Start BIND service
@@ -160,12 +211,14 @@
     enabled: true
   become: true
   tags: bind
+  when: bind_manage_service
 
 - name: Flush handlers to reload BIND
   ansible.builtin.meta: flush_handlers
 
 - name: Synchronize dynamic zones
   ansible.builtin.include_tasks: "sync_dynamic_zones.yml"
+  when: bind_manage_service
 
 - name: Thaw dynamic zones
   ansible.builtin.command:
@@ -173,9 +226,10 @@
   become: true
   changed_when: false
   when: >-
-    ((item.type is defined and item.type == 'primary') or
-    (item.type is not defined and zone_auxiliary[item.name]['primaries_dict'] is defined and
-    (host_all_addresses | intersect(zone_auxiliary[item.name]['primaries_dict'].keys()) | length > 0))) and
-    (ansible_facts.services[bind_service].state == "running") and (item.allow_update | default(false))
+    bind_manage_service and
+    (((item.type is defined and item.type == 'primary') or
+    (item.type is not defined and bind_zone_auxiliary[item.name]['primaries_dict'] is defined and
+    (host_all_addresses | intersect(bind_zone_auxiliary[item.name]['primaries_dict'].keys()) | length > 0))) and
+    (ansible_facts.services[bind_service].state == "running") and (item.allow_update | default(false)))
   with_items: '{{ bind_zones }}'
   tags: bind

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,7 +61,9 @@
     group: "{{ bind_group }}"
     create_home: false
     state: present
-  when: not bind_manage_service
+  when: 
+    - bind_owner != 'root'
+    - not bind_manage_service
 
 - name: Ensure runtime directories referenced in config exist
   ansible.builtin.file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,7 +61,7 @@
     group: "{{ bind_group }}"
     create_home: false
     state: present
-  when: 
+  when:
     - bind_owner != 'root'
     - not bind_manage_service
 

--- a/tasks/sync_dynamic_zones.yml
+++ b/tasks/sync_dynamic_zones.yml
@@ -7,8 +7,8 @@
   when: >
     (item.create_forward_zones is not defined or item.create_forward_zones) and
     ((item.type is defined and item.type == 'primary') or
-    (item.type is not defined and zone_auxiliary[item.name]['primaries_dict'] is defined and
-    (host_all_addresses | intersect(zone_auxiliary[item.name]['primaries_dict'].keys()) | length > 0))) and
+    (item.type is not defined and bind_zone_auxiliary[item.name]['primaries_dict'] is defined and
+    (host_all_addresses | intersect(bind_zone_auxiliary[item.name]['primaries_dict'].keys()) | length > 0))) and
     item.update_policy is defined or item.allow_update is defined
   notify: Reload bind
   changed_when: false
@@ -26,8 +26,8 @@
   when: >
     (item.create_reverse_zones is not defined or item.create_reverse_zones) and
     ((item[0].type is defined and item[0].type == 'primary') or
-    (item[0].type is not defined and zone_auxiliary[item[0].name]['primaries_dict'] is defined and
-    (host_all_addresses | intersect(zone_auxiliary[item[0].name]['primaries_dict'].keys()) | length > 0))) and
+    (item[0].type is not defined and bind_zone_auxiliary[item[0].name]['primaries_dict'] is defined and
+    (host_all_addresses | intersect(bind_zone_auxiliary[item[0].name]['primaries_dict'].keys()) | length > 0))) and
     item[0].update_policy is defined or item[0].allow_update is defined
   notify: Reload bind
   changed_when: false
@@ -45,8 +45,8 @@
   when: >
     (item.create_reverse_zones is not defined or item.create_reverse_zones) and
     ((item[0].type is defined and item[0].type == 'primary') or
-    (item[0].type is not defined and zone_auxiliary[item[0].name]['primaries_dict'] is defined and
-    (host_all_addresses | intersect(zone_auxiliary[item[0].name]['primaries_dict'].keys()) | length > 0))) and
+    (item[0].type is not defined and bind_zone_auxiliary[item[0].name]['primaries_dict'] is defined and
+    (host_all_addresses | intersect(bind_zone_auxiliary[item[0].name]['primaries_dict'].keys()) | length > 0))) and
     item[0].update_policy is defined or item[0].allow_update is defined
   notify: Reload bind
   changed_when: false

--- a/tasks/zones.yml
+++ b/tasks/zones.yml
@@ -73,74 +73,153 @@
     label: "{{ item.1.name |default(item.0.cmd.split(' ')[4]) }}"
   tags: bind
 
-- name: Create forward lookup zone file
-  ansible.builtin.template:
-    src: bind_zone.j2
-    dest: "{{ bind_zone_dir }}/{{ item.name }}"
-    owner: "{{ bind_owner }}"
-    group: "{{ bind_group }}"
-    mode: "{{ bind_zone_file_mode }}"
-    setype: named_zone_t
-    validate: 'named-checkzone -d {{ item.name }} %s'
-  become: true
-  with_items:
-    - "{{ bind_zones }}"
-  loop_control:
-    label: "{{ item.name }}"
-  when: >
-    (item.create_forward_zones is not defined or item.create_forward_zones) and
-    ((item.type is defined and item.type == 'primary') or
-    (item.type is not defined and zone_auxiliary[item.name]['primaries_dict'] is defined and
-    (host_all_addresses | intersect(zone_auxiliary[item.name]['primaries_dict'].keys()) | length > 0)))
-  notify: Reload bind
-  tags: bind
+- name: Check if named-checkconf is available
+  ansible.builtin.command:
+    which named-checkconf
+  register: check_named
+  failed_when: check_named.rc not in [0,1]
+  changed_when: false
 
-- name: Create reverse lookup zone file
-  ansible.builtin.template:
-    src: reverse_zone.j2
-    dest: "{{ bind_zone_dir }}/{{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa"
-    owner: "{{ bind_owner }}"
-    group: "{{ bind_group }}"
-    mode: "{{ bind_zone_file_mode }}"
-    setype: named_zone_t
-    validate: "named-checkzone {{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa %s"
-  become: true
-  with_subelements:
-    - "{{ bind_zones }}"
-    - networks
-    - flags:
-      skip_missing: true
-  loop_control:
-    label: "{{ item.1 }}"
-  when: >
-    (item.create_reverse_zones is not defined or item.create_reverse_zones) and
-    ((item[0].type is defined and item[0].type == 'primary') or
-    (item[0].type is not defined and zone_auxiliary[item[0].name]['primaries_dict'] is defined and
-    (host_all_addresses | intersect(zone_auxiliary[item[0].name]['primaries_dict'].keys()) | length > 0)))
-  notify: Reload bind
-  tags: bind
+- name: Create lookup zone files (with validation)
+  when: check_named.rc == 0
+  block:
+    - name: Create forward lookup zone file
+      ansible.builtin.template:
+        src: bind_zone.j2
+        dest: "{{ bind_zone_dir }}/{{ item.name }}"
+        owner: "{{ bind_owner }}"
+        group: "{{ bind_group }}"
+        mode: "{{ bind_zone_file_mode }}"
+        setype: named_zone_t
+        validate: 'named-checkzone -d {{ item.name }} %s'
+      become: true
+      with_items:
+        - "{{ bind_zones }}"
+      loop_control:
+        label: "{{ item.name }}"
+      when: >
+        (item.create_forward_zones is not defined or item.create_forward_zones) and
+        ((item.type is defined and item.type == 'primary') or
+        (item.type is not defined and bind_zone_auxiliary[item.name]['primaries_dict'] is defined and
+        (host_all_addresses | intersect(bind_zone_auxiliary[item.name]['primaries_dict'].keys()) | length > 0)))
+      notify: Reload bind
+      tags: bind
 
-- name: Create reverse IPv6 lookup zone file
-  ansible.builtin.template:
-    src: reverse_zone_ipv6.j2
-    dest: "{{ bind_zone_dir }}/{{ (item.1 | ansible.utils.ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }}"
-    owner: "{{ bind_owner }}"
-    group: "{{ bind_group }}"
-    mode: "{{ bind_zone_file_mode }}"
-    setype: named_zone_t
-    validate: "named-checkzone {{ (item.1 | ansible.utils.ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):] }} %s"
-  become: true
-  with_subelements:
-    - "{{ bind_zones }}"
-    - ipv6_networks
-    - flags:
-      skip_missing: true
-  loop_control:
-    label: "{{ item.1 }}"
-  when: >
-    (item.create_reverse_zones is not defined or item.create_reverse_zones) and
-    ((item[0].type is defined and item[0].type == 'primary') or
-    (item[0].type is not defined and zone_auxiliary[item[0].name]['primaries_dict'] is defined and
-    (host_all_addresses | intersect(zone_auxiliary[item[0].name]['primaries_dict'].keys()) | length > 0)))
-  notify: Reload bind
-  tags: bind
+    - name: Create reverse lookup zone file
+      ansible.builtin.template:
+        src: reverse_zone.j2
+        dest: "{{ bind_zone_dir }}/{{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa"
+        owner: "{{ bind_owner }}"
+        group: "{{ bind_group }}"
+        mode: "{{ bind_zone_file_mode }}"
+        setype: named_zone_t
+        validate: "named-checkzone {{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa %s"
+      become: true
+      with_subelements:
+        - "{{ bind_zones }}"
+        - networks
+        - flags:
+          skip_missing: true
+      loop_control:
+        label: "{{ item.1 }}"
+      when: >
+        (item.create_reverse_zones is not defined or item.create_reverse_zones) and
+        ((item[0].type is defined and item[0].type == 'primary') or
+        (item[0].type is not defined and bind_zone_auxiliary[item[0].name]['primaries_dict'] is defined and
+        (host_all_addresses | intersect(bind_zone_auxiliary[item[0].name]['primaries_dict'].keys()) | length > 0)))
+      notify: Reload bind
+      tags: bind
+
+    - name: Create reverse IPv6 lookup zone file
+      ansible.builtin.template:
+        src: reverse_zone_ipv6.j2
+        dest: "{{ bind_zone_dir }}/{{ (item.1 | ansible.utils.ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }}"
+        owner: "{{ bind_owner }}"
+        group: "{{ bind_group }}"
+        mode: "{{ bind_zone_file_mode }}"
+        setype: named_zone_t
+        validate: "named-checkzone {{ (item.1 | ansible.utils.ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):] }} %s"
+      become: true
+      with_subelements:
+        - "{{ bind_zones }}"
+        - ipv6_networks
+        - flags:
+          skip_missing: true
+      loop_control:
+        label: "{{ item.1 }}"
+      when: >
+        (item.create_reverse_zones is not defined or item.create_reverse_zones) and
+        ((item[0].type is defined and item[0].type == 'primary') or
+        (item[0].type is not defined and bind_zone_auxiliary[item[0].name]['primaries_dict'] is defined and
+        (host_all_addresses | intersect(bind_zone_auxiliary[item[0].name]['primaries_dict'].keys()) | length > 0)))
+      notify: Reload bind
+      tags: bind
+
+- name: Create lookup zone files (without validation)
+  when: check_named.rc == 0
+  block:
+    - name: Create forward lookup zone file
+      ansible.builtin.template:
+        src: bind_zone.j2
+        dest: "{{ bind_zone_dir }}/{{ item.name }}"
+        owner: "{{ bind_owner }}"
+        group: "{{ bind_group }}"
+        mode: "{{ bind_zone_file_mode }}"
+        setype: named_zone_t
+      become: true
+      with_items:
+        - "{{ bind_zones }}"
+      loop_control:
+        label: "{{ item.name }}"
+      when: >
+        (item.create_forward_zones is not defined or item.create_forward_zones) and
+        ((item.type is defined and item.type == 'primary') or
+        (item.type is not defined and bind_zone_auxiliary[item.name]['primaries_dict'] is defined and
+        (host_all_addresses | intersect(bind_zone_auxiliary[item.name]['primaries_dict'].keys()) | length > 0)))
+      tags: bind
+
+    - name: Create reverse lookup zone file
+      ansible.builtin.template:
+        src: reverse_zone.j2
+        dest: "{{ bind_zone_dir }}/{{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa"
+        owner: "{{ bind_owner }}"
+        group: "{{ bind_group }}"
+        mode: "{{ bind_zone_file_mode }}"
+        setype: named_zone_t
+      become: true
+      with_subelements:
+        - "{{ bind_zones }}"
+        - networks
+        - flags:
+          skip_missing: true
+      loop_control:
+        label: "{{ item.1 }}"
+      when: >
+        (item.create_reverse_zones is not defined or item.create_reverse_zones) and
+        ((item[0].type is defined and item[0].type == 'primary') or
+        (item[0].type is not defined and bind_zone_auxiliary[item[0].name]['primaries_dict'] is defined and
+        (host_all_addresses | intersect(bind_zone_auxiliary[item[0].name]['primaries_dict'].keys()) | length > 0)))
+      tags: bind
+
+    - name: Create reverse IPv6 lookup zone file
+      ansible.builtin.template:
+        src: reverse_zone_ipv6.j2
+        dest: "{{ bind_zone_dir }}/{{ (item.1 | ansible.utils.ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }}"
+        owner: "{{ bind_owner }}"
+        group: "{{ bind_group }}"
+        mode: "{{ bind_zone_file_mode }}"
+        setype: named_zone_t
+      become: true
+      with_subelements:
+        - "{{ bind_zones }}"
+        - ipv6_networks
+        - flags:
+          skip_missing: true
+      loop_control:
+        label: "{{ item.1 }}"
+      when: >
+        (item.create_reverse_zones is not defined or item.create_reverse_zones) and
+        ((item[0].type is defined and item[0].type == 'primary') or
+        (item[0].type is not defined and bind_zone_auxiliary[item[0].name]['primaries_dict'] is defined and
+        (host_all_addresses | intersect(bind_zone_auxiliary[item[0].name]['primaries_dict'].keys()) | length > 0)))
+      tags: bind

--- a/templates/etc_named.conf.j2
+++ b/templates/etc_named.conf.j2
@@ -117,9 +117,9 @@ include "{{ bind_tsig_file }}";
 {% if bind_zones is defined %}
 {% for bind_zone in bind_zones %}
 {# Generate a list of primaries strings including additional properts (e.g. a port specification) #}
-{% if zone_auxiliary[bind_zone.name] is defined and zone_auxiliary[bind_zone.name]['primaries_dict'] is defined%}
+{% if bind_zone_auxiliary[bind_zone.name] is defined and bind_zone_auxiliary[bind_zone.name]['primaries_dict'] is defined%}
 {% set _primaries = [] %}
-{% for primary in zone_auxiliary[bind_zone.name]['primaries_dict'].values() %}
+{% for primary in bind_zone_auxiliary[bind_zone.name]['primaries_dict'].values() %}
 {% set primary_string = primary.ip %}
 {% if primary.port is defined %}
 {% set primary_string = primary_string + ' port ' + primary.port | string %}
@@ -128,9 +128,9 @@ include "{{ bind_tsig_file }}";
 {% endfor %}
 {% endif %}
 {# Build forwarders #}
-{% if zone_auxiliary[bind_zone.name] is defined and zone_auxiliary[bind_zone.name]['forwarders_dict'] is defined%}
+{% if bind_zone_auxiliary[bind_zone.name] is defined and bind_zone_auxiliary[bind_zone.name]['forwarders_dict'] is defined%}
 {% set _forwarders = [] %}
-{% for forwarder in zone_auxiliary[bind_zone.name]['forwarders_dict'].values() %}
+{% for forwarder in bind_zone_auxiliary[bind_zone.name]['forwarders_dict'].values() %}
 {% set forwarder_string = forwarder.ip %}
 {% if forwarder.port is defined %}
 {% set forwarder_string = forwarder_string + ' port ' + forwarder.port | string %}
@@ -139,9 +139,9 @@ include "{{ bind_tsig_file }}";
 {% endfor %}
 {% endif %}
 {# Build also-notify #}
-{% if zone_auxiliary[bind_zone.name] is defined and zone_auxiliary[bind_zone.name]['also_notify_dict'] is defined%}
+{% if bind_zone_auxiliary[bind_zone.name] is defined and bind_zone_auxiliary[bind_zone.name]['also_notify_dict'] is defined%}
 {% set _also_notify = [] %}
-{% for also_notify in zone_auxiliary[bind_zone.name]['also_notify_dict'].values() %}
+{% for also_notify in bind_zone_auxiliary[bind_zone.name]['also_notify_dict'].values() %}
 {% set also_notify_string = also_notify.ip %}
 {% if also_notify.port is defined %}
 {% set also_notify_string = also_notify_string + ' port ' + also_notify.port | string %}
@@ -157,9 +157,9 @@ include "{{ bind_tsig_file }}";
 {% set _type = 'secondary' %}
 {% elif bind_zone.type is defined and bind_zone.type == 'forward' %}
 {% set _type = 'forward' %}
-{% elif bind_zone.type is not defined and bind_zone.primaries is defined and (host_all_addresses|intersect(zone_auxiliary[bind_zone.name]['primaries_dict'])|length > 0) %}
+{% elif bind_zone.type is not defined and bind_zone.primaries is defined and (host_all_addresses|intersect(bind_zone_auxiliary[bind_zone.name]['primaries_dict'])|length > 0) %}
 {% set _type = 'primary' %}
-{% elif bind_zone.type is not defined and bind_zone.primaries is defined and not (host_all_addresses|intersect(zone_auxiliary[bind_zone.name]['primaries_dict'])|length > 0) %}
+{% elif bind_zone.type is not defined and bind_zone.primaries is defined and not (host_all_addresses|intersect(bind_zone_auxiliary[bind_zone.name]['primaries_dict'])|length > 0) %}
 {% set _type = 'secondary' %}
 {% elif bind_zone.type is not defined and bind_zone.forwarders is defined %}
 {% set _type = 'forward' %}
@@ -168,7 +168,7 @@ include "{{ bind_tsig_file }}";
 
 {# Start: set mapped primaries for the zone #}
 {% if bind_key_mapping | length != 0 %}
-{% set _mapped_zone_primaries = bind_key_mapping.keys() | intersect(zone_auxiliary[bind_zone.name]['primaries_dict']) %}
+{% set _mapped_zone_primaries = bind_key_mapping.keys() | intersect(bind_zone_auxiliary[bind_zone.name]['primaries_dict']) %}
 {% else %}
 {% set _mapped_zone_primaries = [] %}
 {% endif %}


### PR DESCRIPTION
Added new flag `bind_manage_service` to control whether bind is installed, started and the service is enabled.
If set to `false`, the role only generates the bind configuration files without installing the packages or reloading the service.
