### PR TITLE
Enh/master file format

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,66 +36,68 @@ The packages `python-netaddr` (required for the [`ansible.utils.ipaddr`](https:/
 
 ## Role Variables
 
-| Variable                    | Default              | Comments (type)                                                                                                                      |
-| :-------------------------- | :------------------- | :----------------------------------------------------------------------------------------------------------------------------------- |
-| `bind_manage_service`       | `true`               | Indicating whether to install, start and enable bind. If set to `false`, only the configuration is generated (but not verified).     |
-| `bind_acls`                 | `[]`                 | A list of ACL definitions, which are mappings with keys `name:` and `match_list:`. See below for an example.                         |
-| `bind_allow_query`          | `['localhost']`      | A list of hosts that are allowed to query this DNS server. Set to ['any'] to allow all hosts                                         |
-| `bind_allow_recursion`      | `['any']`            | Similar to `bind_allow_query`, this option applies to recursive queries.                                                             |
-| `bind_allow_transfer`       | `[]`                 | A list of hosts that allowed to transfer (copy) the zone information from the server                                                 |
-| `bind_check_names`          | `[]`                 | Check host names for compliance with RFC 952 and RFC 1123 and take the defined action (e.g. `warn`, `ignore`, `fail`).               |
-| `bind_dns_keys`             | `[]`                 | A list of binding keys, which are mappings with keys `name:` `algorithm:` and `secret:`. See below for an example.                   |
-| `bind_tsig_keys`            | `[]`                 | A list of tsig keys, which are mappings with keys `name:` `algorithm:` and `secret:`. See below for an example.                      |
-| `bind_dns64`                | `false`              | If `true`, support for [DNS64](https://www.oreilly.com/library/view/dns-and-bind/9781449308025/ch04.html) is enabled                 |
-| `bind_dns64_clients`        | `['any']`            | A list of clients which the DNS64 function applies to (can be any ACL)                                                               |
-| `bind_dnssec_enable`        | `true`               | If `true`, DNSSEC is enabled                                                                                                         |
-| `bind_dnssec_validation`    | `true`               | If `true`, DNSSEC validation is enabled                                                                                              |
-| `bind_extra_include_files`  | `[]`                 | A list of custom config files to be included from the main config file                                                               |
-| `bind_forward_only`         | `false`              | If `true`, BIND is set up as a caching name server                                                                                   |
-| `bind_forwarders`           | `[]`                 | A list of name servers to forward DNS requests to.                                                                                   |
-| `bind_listen_ipv4`          | `['127.0.0.1']`      | A list of the IPv4 address of the network interface(s) to listen on. Set to ['any'] to listen on all interfaces.                     |
-| `bind_listen_ipv4_port`     | `[53]`               | A list of port numbers to listen on for IPv4 addresses.                                                                              |
-| `bind_listen_ipv6`          | `['::1']`            | A list of the IPv6 address of the network interface(s) to listen on                                                                  |
-| `bind_listen_ipv6_port`     | `[53]`               | A list of port numbers to listen on for IPv6 addresses.                                                                              |
-| `bind_log`                  | `data/named.run`     | Path to the log file                                                                                                                 |
-| `bind_other_logs`           | -                    | A list of logging channels to configure, with a separate mapping for each zone, with relevant details                                |
-| `bind_query_log`            | -                    | A mapping with keyss `file:` (e.g. `data/query.log`), `versions:`, `size:`. When defined, this will enable the query log             |
-| `bind_recursion`            | `false`              | Determines whether requests for which the DNS server is not authoritative should be forwarded†.                                      |
-| `bind_rrset_order`          | `random`             | Defines order for DNS round robin (either `random` or `cyclic`)                                                                      |
-| `bind_statistics_channels`  | `false`              | If `true`, BIND is configured with a `statistics-channels` clause (currently only supports listening on a single interface)          |
-| `bind_statistics_allow`     | `['127.0.0.1']`      | A list of hosts that can access the server statistics                                                                                |
-| `bind_statistics_host`      | `127.0.0.1`          | IP address of the network interface that the statistics service should listen on                                                     |
-| `bind_statistics_port`      | 8053                 | Network port that the statistics service should listen on                                                                            |
-| `bind_zone_dir`             | -                    | When defined, sets a custom absolute path to the server directory (for zone files, etc.) instead of the default.                     |
-| `bind_key_mapping`          | []                   | `Primary: Keyname` - mapping of TSIG keys to use for a specific primary                                                              |
-| `bind_zones`                | n/a                  | A list of mappings with zone definitions. See below this table for examples                                                          |
-| `- allow_update`            | `['none']`           | A list of hosts that are allowed to dynamically update this DNS zone.                                                                |
-| `- also_notify`             | -                    | A list of servers that will receive a notification when the primary zone file is reloaded.                                           |
-| `- create_forward_zones`    | -                    | When initialized and set to `false`, creation of forward zones will be skipped (resulting in a reverse only zone)                    |
-| `- create_reverse_zones`    | -                    | When initialized and set to `false`, creation of reverse zones will be skipped (resulting in a forward only zone)                    |
-| `- delegate`                | `[]`                 | Zone delegation.                                                                                                                     |
-| `- forwarders`              | -                    | List of forwarders for for the forward type zone                                                                                     |
-| `- hostmaster_email`        | `hostmaster`         | The e-mail address of the system administrator for the zone                                                                          |
-| `- hosts`                   | `[]`                 | Host definitions.                                                                                                                    |
-| `- ipv6_networks`           | `[]`                 | A list of the IPv6 networks that are part of the domain, in CIDR notation (e.g. 2001:db8::/48)                                       |
-| `- mail_servers`            | `[]`                 | A list of mappings (with keys `name:` and `preference:`) specifying the mail servers for this domain.                                |
-| `- name_servers`            | `[ansible_hostname]` | A list of the DNS servers for this domain.                                                                                           |
-| `- name`                    | `example.com`        | The domain name                                                                                                                      |
-| `- naptr`                   | `[]`                 | A list of mappings with keys `name:`, `order:`, `pref:`, `flags:`, `service:`, `regex:` and `replacement:` specifying NAPTR records. |
-| `- networks`                | `['10.0.2']`         | A list of the networks that are part of the domain                                                                                   |
-| `- other_name_servers`      | `[]`                 | A list of the DNS servers outside of this domain.                                                                                    |
-| `- primaries`               | -                    | A list of primary DNS servers for this zone.                                                                                         |
-| `- services`                | `[]`                 | A list of services to be advertised by SRV records                                                                                   |
-| `- text`                    | `[]`                 | A list of mappings with keys `name:` and `text:`, specifying TXT records. `text:` can be a list or string.                           |
-| `- caa`                     | `[]`                 | A list of mappings with keys `name:` and `text:`, specifying CAA records. `text:` can be a list or string.                           |
-| `- type`                    | -                    | Optional zone type. If not specified, autodetection will be used. Possible values include `primary`, `secondary` or `forward`        |
-| `bind_zone_file_mode`       | 0640                 | The file permissions for the main config file (named.conf)                                                                           |
-| `bind_zone_minimum_ttl`     | `1D`                 | Minimum TTL field in the SOA record.                                                                                                 |
-| `bind_zone_time_to_expire`  | `1W`                 | Time to expire field in the SOA record.                                                                                              |
-| `bind_zone_time_to_refresh` | `1D`                 | Time to refresh field in the SOA record.                                                                                             |
-| `bind_zone_time_to_retry`   | `1H`                 | Time to retry field in the SOA record.                                                                                               |
-| `bind_zone_ttl`             | `1W`                 | Time to Live field in the SOA record.                                                                                                |
-| `bind_python_version`       | -                    | The python version that should be used for ansible. Depends on Distro, either `2` or `3`. Defaults to the OS standard                |
+| Variable                                           | Default              | Comments (type)                                                                                                                      |
+| :------------------------------------------------- | :------------------- | :----------------------------------------------------------------------------------------------------------------------------------- |
+| `bind_manage_service`                              | `true`               | Indicating whether to install, start and enable bind. If set to `false`, only the configuration is generated (but not verified).     |
+| `bind_acls`                                        | `[]`                 | A list of ACL definitions, which are mappings with keys `name:` and `match_list:`. See below for an example.                         |
+| `bind_allow_query`                                 | `['localhost']`      | A list of hosts that are allowed to query this DNS server. Set to ['any'] to allow all hosts                                         |
+| `bind_allow_recursion`                             | `['any']`            | Similar to `bind_allow_query`, this option applies to recursive queries.                                                             |
+| `bind_allow_transfer`                              | `[]`                 | A list of hosts that allowed to transfer (copy) the zone information from the server                                                 |
+| `bind_check_names`                                 | `[]`                 | Check host names for compliance with RFC 952 and RFC 1123 and take the defined action (e.g. `warn`, `ignore`, `fail`).               |
+| `bind_dns_keys`                                    | `[]`                 | A list of binding keys, which are mappings with keys `name:` `algorithm:` and `secret:`. See below for an example.                   |
+| `bind_tsig_keys`                                   | `[]`                 | A list of tsig keys, which are mappings with keys `name:` `algorithm:` and `secret:`. See below for an example.                      |
+| `bind_dns64`                                       | `false`              | If `true`, support for [DNS64](https://www.oreilly.com/library/view/dns-and-bind/9781449308025/ch04.html) is enabled                 |
+| `bind_dns64_clients`                               | `['any']`            | A list of clients which the DNS64 function applies to (can be any ACL)                                                               |
+| `bind_dnssec_enable`                               | `true`               | If `true`, DNSSEC is enabled                                                                                                         |
+| `bind_dnssec_validation`                           | `true`               | If `true`, DNSSEC validation is enabled                                                                                              |
+| `bind_extra_include_files`                         | `[]`                 | A list of custom config files to be included from the main config file                                                               |
+| `bind_forward_only`                                | `false`              | If `true`, BIND is set up as a caching name server                                                                                   |
+| `bind_forwarders`                                  | `[]`                 | A list of name servers to forward DNS requests to.                                                                                   |
+| `bind_listen_ipv4`                                 | `['127.0.0.1']`      | A list of the IPv4 address of the network interface(s) to listen on. Set to ['any'] to listen on all interfaces.                     |
+| `bind_listen_ipv4_port`                            | `[53]`               | A list of port numbers to listen on for IPv4 addresses.                                                                              |
+| `bind_listen_ipv6`                                 | `['::1']`            | A list of the IPv6 address of the network interface(s) to listen on                                                                  |
+| `bind_listen_ipv6_port`                            | `[53]`               | A list of port numbers to listen on for IPv6 addresses.                                                                              |
+| `bind_log`                                         | `data/named.run`     | Path to the log file                                                                                                                 |
+| `bind_other_logs`                                  | -                    | A list of logging channels to configure, with a separate mapping for each zone, with relevant details                                |
+| `bind_query_log`                                   | -                    | A mapping with keyss `file:` (e.g. `data/query.log`), `versions:`, `size:`. When defined, this will enable the query log             |
+| `bind_recursion`                                   | `false`              | Determines whether requests for which the DNS server is not authoritative should be forwarded†.                                      |
+| `bind_rrset_order`                                 | `random`             | Defines order for DNS round robin (either `random` or `cyclic`)                                                                      |
+| `bind_statistics_channels`                         | `false`              | If `true`, BIND is configured with a `statistics-channels` clause (currently only supports listening on a single interface)          |
+| `bind_statistics_allow`                            | `['127.0.0.1']`      | A list of hosts that can access the server statistics                                                                                |
+| `bind_statistics_host`                             | `127.0.0.1`          | IP address of the network interface that the statistics service should listen on                                                     |
+| `bind_statistics_port`                             | 8053                 | Network port that the statistics service should listen on                                                                            |
+| `bind_zone_dir`                                    | -                    | When defined, sets a custom absolute path to the server directory (for zone files, etc.) instead of the default.                     |
+| `bind_key_mapping`                                 | []                   | `Primary: Keyname` - mapping of TSIG keys to use for a specific primary                                                              |
+| `bind_zones`                                       | n/a                  | A list of mappings with zone definitions. See below this table for examples                                                          |
+| `- allow_update`                                   | `['none']`           | A list of hosts that are allowed to dynamically update this DNS zone.                                                                |
+| `- also_notify`                                    | -                    | A list of servers that will receive a notification when the primary zone file is reloaded.                                           |
+| `- create_forward_zones`                           | -                    | When initialized and set to `false`, creation of forward zones will be skipped (resulting in a reverse only zone)                    |
+| `- create_reverse_zones`                           | -                    | When initialized and set to `false`, creation of reverse zones will be skipped (resulting in a forward only zone)                    |
+| `- delegate`                                       | `[]`                 | Zone delegation.                                                                                                                     |
+| `- forwarders`                                     | -                    | List of forwarders for for the forward type zone                                                                                     |
+| `- hostmaster_email`                               | `hostmaster`         | The e-mail address of the system administrator for the zone                                                                          |
+| `- hosts`                                          | `[]`                 | Host definitions.                                                                                                                    |
+| `- ipv6_networks`                                  | `[]`                 | A list of the IPv6 networks that are part of the domain, in CIDR notation (e.g. 2001:db8::/48)                                       |
+| `- mail_servers`                                   | `[]`                 | A list of mappings (with keys `name:` and `preference:`) specifying the mail servers for this domain.                                |
+| `- name_servers`                                   | `[ansible_hostname]` | A list of the DNS servers for this domain.                                                                                           |
+| `- name`                                           | `example.com`        | The domain name                                                                                                                      |
+| `- naptr`                                          | `[]`                 | A list of mappings with keys `name:`, `order:`, `pref:`, `flags:`, `service:`, `regex:` and `replacement:` specifying NAPTR records. |
+| `- networks`                                       | `['10.0.2']`         | A list of the networks that are part of the domain                                                                                   |
+| `- other_name_servers`                             | `[]`                 | A list of the DNS servers outside of this domain.                                                                                    |
+| `- primaries`                                      | -                    | A list of primary DNS servers for this zone.                                                                                         |
+| `- services`                                       | `[]`                 | A list of services to be advertised by SRV records                                                                                   |
+| `- text`                                           | `[]`                 | A list of mappings with keys `name:` and `text:`, specifying TXT records. `text:` can be a list or string.                           |
+| `- caa`                                            | `[]`                 | A list of mappings with keys `name:` and `text:`, specifying CAA records. `text:` can be a list or string.                           |
+| `- type`                                           | -                    | Optional zone type. If not specified, autodetection will be used. Possible values include `primary`, `secondary` or `forward`        |
+| `- masterfile_format`                              | -                    | Sets the file format to store zone files in. Allowed values: `text`, `raw`                                                           |
+| `bind_zone_file_mode`                              | 0640                 | The file permissions for the main config file (named.conf)                                                                           |
+| `bind_zone_minimum_ttl`                            | `1D`                 | Minimum TTL field in the SOA record.                                                                                                 |
+| `bind_zone_time_to_expire`                         | `1W`                 | Time to expire field in the SOA record.                                                                                              |
+| `bind_zone_time_to_refresh`                        | `1D`                 | Time to refresh field in the SOA record.                                                                                             |
+| `bind_zone_time_to_retry`                          | `1H`                 | Time to retry field in the SOA record.                                                                                               |
+| `bind_zone_ttl`                                    | `1W`                 | Time to Live field in the SOA record.                                                                                                |
+| `bind_python_version`                              | -                    | The python version that should be used for ansible. Depends on Distro, either `2` or `3`. Defaults to the OS standard                |
+| `bind_reverse_lookup_zone_masterfile_format`       | -                    | `masterfile_format` for reverse lookup zone files, allwoed values: `text`, `raw`                                                     |
 
 † Best practice for an authoritative name server is to leave recursion turned off. However, [for some cases](http://www.zytrax.com/books/dns/ch7/queries.html#allow-query-cache) it may be necessary to have recursion turned on.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -100,3 +100,6 @@ bind_max_cache_size: ""
 
 # Flag indicating whether to start / reload BIND (if false, only the configuration will be created/updated)
 bind_manage_service: true
+
+# Setting for reverse lookup zone file format, either 'text' or 'raw'
+bind_reverse_lookup_zone_masterfile_format: "text"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -102,4 +102,4 @@ bind_max_cache_size: ""
 bind_manage_service: true
 
 # Setting for reverse lookup zone file format, either 'text' or 'raw'
-bind_reverse_lookup_zone_masterfile_format: "text"
+bind_reverse_lookup_zone_masterfile_format: ""

--- a/molecule/shared_inventory_raw/converge.yml
+++ b/molecule/shared_inventory_raw/converge.yml
@@ -1,0 +1,9 @@
+---
+
+# Remark that common variables are defined in `group_vars/all.yml`
+
+- name: Primary/Secondary with Shared Inventory
+  hosts: dns
+
+  roles:
+    - role: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule/shared_inventory_raw/group_vars/all.yml
+++ b/molecule/shared_inventory_raw/group_vars/all.yml
@@ -1,0 +1,120 @@
+---
+bind_statistics_channels: true
+bind_statistics_allow:
+  - any
+bind_zone_dir: /var/local/named-zones
+bind_zone_file_mode: '0660'
+bind_allow_query:
+  - any
+bind_listen_ipv4:
+  - any
+bind_listen_ipv6:
+  - any
+bind_acls:
+  - name: acl1
+    match_list:
+      - 10.11.0/16
+bind_forwarders:
+  - '8.8.8.8'
+  - '8.8.4.4'
+bind_recursion: true
+bind_dns64: true
+bind_query_log: 'data/query.log'
+bind_check_names: 'master ignore'
+bind_zone_minimum_ttl: "2D"
+bind_zone_ttl: "2W"
+bind_zone_time_to_refresh: "2D"
+bind_zone_time_to_retry: "2H"
+bind_zone_time_to_expire: "2W"
+bind_reverse_lookup_zone_masterfile_format: "raw"
+bind_zones:
+  - name: 'example.com'
+    primaries:
+      - 10.11.0.4
+    networks:
+      - '192.0.2'
+    ipv6_networks:
+      - '2001:db9::/48'
+    name_servers:
+      - ns1.acme-inc.com.
+      - ns2.acme-inc.com.
+    hostmaster_email: admin
+    hosts:
+      - name: srv001
+        ip: 192.0.2.1
+        ipv6: '2001:db9::1'
+        aliases:
+          - www
+      - name: srv002
+        ip: 192.0.2.2
+        ipv6: '2001:db9::2'
+      - name: mail001
+        ip: 192.0.2.10
+        ipv6: '2001:db9::3'
+    mail_servers:
+      - name: mail001
+        preference: 10
+    masterfile_format: raw
+  - name: 'acme-inc.com'
+    primaries:
+      - 10.11.0.4
+    networks:
+      - '10.11'
+    ipv6_networks:
+      - '2001:db8::/48'
+    name_servers:
+      - ns1
+      - ns2
+    hosts:
+      - name: ns1
+        ip: 10.11.0.4
+      - name: ns2
+        ip: 10.11.0.5
+      - name: srv001
+        ip: 10.11.1.1
+        ipv6: 2001:db8::1
+        aliases:
+          - www
+      - name: srv002
+        ip: 10.11.1.2
+        ipv6: 2001:db8::2
+        aliases:
+          - mysql
+      - name: mail001
+        ip: 10.11.2.1
+        ipv6: 2001:db8::d:1
+        aliases:
+          - smtp
+          - mail-in
+      - name: mail002
+        ip: 10.11.2.2
+        ipv6: 2001:db8::d:2
+      - name: mail003
+        ip: 10.11.2.3
+        ipv6: 2001:db8::d:3
+        aliases:
+          - imap
+          - mail-out
+      - name: srv010
+        ip: 10.11.0.10
+      - name: srv011
+        ip: 10.11.0.11
+      - name: srv012
+        ip: 10.11.0.12
+    mail_servers:
+      - name: mail001
+        preference: 10
+      - name: mail002
+        preference: 20
+    services:
+      - name: _ldap._tcp
+        weight: 100
+        port: 88
+        target: srv010
+    text:
+      - name: _kerberos
+        text: KERBEROS.ACME-INC.COM
+      - name: '@'
+        text:
+          - 'some text'
+          - 'more text'

--- a/molecule/shared_inventory_raw/molecule.yml
+++ b/molecule/shared_inventory_raw/molecule.yml
@@ -1,0 +1,72 @@
+---
+dependency:
+  name: galaxy
+
+driver:
+  # Specifies the driver that should be used. Podman should also work
+  name: docker
+
+lint: |
+  set -e
+  yamllint .
+  ansible-lint -x 106 .
+
+platforms:
+  # Set name and hostname
+  - name: ns4
+    groups:
+      - dns
+    hostname: ns4
+    docker_networks:
+      - name: bind
+        ipam_config:
+          - subnet: "10.11.0.0/16"
+            gateway: "10.11.0.254"
+    networks:
+      - name: bind
+        ipv4_address: "10.11.0.4"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - ${PWD}:/etc/ansible/roles/bertvv.bind:ro
+      - ${PWD}/library:/root/.ansible/plugins/modules:ro
+    privileged: true
+    cgroupns_mode: host
+    pre_build_image: true
+    tty: true
+    environment:
+      container: docker
+
+  - name: ns5
+    hostname: ns5
+    groups:
+      - dns
+    networks:
+      - name: bind
+        ipv4_address: "10.11.0.5"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - ${PWD}:/etc/ansible/roles/bertvv.bind:ro
+      - ${PWD}/library:/root/.ansible/plugins/modules:ro
+    privileged: true
+    cgroupns_mode: host
+    pre_build_image: true
+    tty: true
+    environment:
+      container: docker
+
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      interpreter_python: auto_legacy_silent
+      callback_whitelist: profile_tasks
+    ssh_connection:
+      pipelining: true
+
+# Runs the verify.yml playbook
+verifier:
+  name: ansible

--- a/molecule/shared_inventory_raw/verify.yml
+++ b/molecule/shared_inventory_raw/verify.yml
@@ -1,0 +1,103 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    # Only collect network facts to reduce setup time
+    - name: Gathering Facts
+      ansible.builtin.setup:
+        gather_subset:
+          - 'network'
+
+    - name: Set local_dns variable for dig
+      ansible.builtin.set_fact:
+        local_dns: "{{ '@' + ansible_default_ipv4.address }}"
+
+    - name: IPv4 Forward lookups
+      ansible.builtin.assert:
+        that:
+          - lookup('community.general.dig', 'ns1.acme-inc.com', local_dns )    == '10.11.0.4'
+          - lookup('community.general.dig', 'ns2.acme-inc.com', local_dns)     == '10.11.0.5'
+          - lookup('community.general.dig', 'srv001.acme-inc.com', local_dns)  == '10.11.1.1'
+          - lookup('community.general.dig', 'srv002.acme-inc.com', local_dns)  == '10.11.1.2'
+          - lookup('community.general.dig', 'mail001.acme-inc.com', local_dns) == '10.11.2.1'
+          - lookup('community.general.dig', 'mail002.acme-inc.com', local_dns) == '10.11.2.2'
+          - lookup('community.general.dig', 'mail003.acme-inc.com', local_dns) == '10.11.2.3'
+          - lookup('community.general.dig', 'srv010.acme-inc.com', local_dns)  == '10.11.0.10'
+          - lookup('community.general.dig', 'srv011.acme-inc.com', local_dns)  == '10.11.0.11'
+          - lookup('community.general.dig', 'srv012.acme-inc.com', local_dns)  == '10.11.0.12'
+          - lookup('community.general.dig', 'srv001.example.com', local_dns)   == '192.0.2.1'
+          - lookup('community.general.dig', 'srv002.example.com', local_dns)   == '192.0.2.2'
+          - lookup('community.general.dig', 'mail001.example.com', local_dns)  == '192.0.2.10'
+
+    - name: IPv4 Reverse lookups
+      ansible.builtin.assert:
+        that:
+          - lookup('community.general.dig', '10.11.0.4/PTR', local_dns)  == 'ns1.acme-inc.com.'
+          - lookup('community.general.dig', '10.11.0.5/PTR', local_dns)  == 'ns2.acme-inc.com.'
+          - lookup('community.general.dig', '10.11.1.1/PTR', local_dns)  == 'srv001.acme-inc.com.'
+          - lookup('community.general.dig', '10.11.1.2/PTR', local_dns)  == 'srv002.acme-inc.com.'
+          - lookup('community.general.dig', '10.11.2.1/PTR', local_dns)  == 'mail001.acme-inc.com.'
+          - lookup('community.general.dig', '10.11.2.2/PTR', local_dns)  == 'mail002.acme-inc.com.'
+          - lookup('community.general.dig', '10.11.2.3/PTR', local_dns)  == 'mail003.acme-inc.com.'
+          - lookup('community.general.dig', '10.11.0.10/PTR', local_dns) == 'srv010.acme-inc.com.'
+          - lookup('community.general.dig', '10.11.0.11/PTR', local_dns) == 'srv011.acme-inc.com.'
+          - lookup('community.general.dig', '10.11.0.12/PTR', local_dns) == 'srv012.acme-inc.com.'
+          - lookup('community.general.dig', '192.0.2.1/PTR', local_dns)  == 'srv001.example.com.'
+          - lookup('community.general.dig', '192.0.2.2/PTR', local_dns)  == 'srv002.example.com.'
+          - lookup('community.general.dig', '192.0.2.10/PTR', local_dns) == 'mail001.example.com.'
+
+    - name: IPv4 Alias lookups
+      ansible.builtin.assert:
+        that:
+          - lookup('community.general.dig', 'www.acme-inc.com', local_dns)      == '10.11.1.1'
+          - lookup('community.general.dig', 'mysql.acme-inc.com', local_dns)    == '10.11.1.2'
+          - lookup('community.general.dig', 'smtp.acme-inc.com', local_dns)     == '10.11.2.1'
+          - lookup('community.general.dig', 'mail-in.acme-inc.com', local_dns)  == '10.11.2.1'
+          - lookup('community.general.dig', 'imap.acme-inc.com', local_dns)     == '10.11.2.3'
+          - lookup('community.general.dig', 'mail-out.acme-inc.com', local_dns) == '10.11.2.3'
+          - lookup('community.general.dig', 'www.example.com', local_dns)       == '192.0.2.1'
+
+    - name: IPv6 Forward lookups
+      ansible.builtin.assert:
+        that:
+          - lookup('community.general.dig', 'srv001.acme-inc.com/AAAA', local_dns)  == '2001:db8::1'
+          - lookup('community.general.dig', 'srv002.acme-inc.com/AAAA', local_dns)  == '2001:db8::2'
+          - lookup('community.general.dig', 'mail001.acme-inc.com/AAAA', local_dns) == '2001:db8::d:1'
+          - lookup('community.general.dig', 'mail002.acme-inc.com/AAAA', local_dns) == '2001:db8::d:2'
+          - lookup('community.general.dig', 'mail003.acme-inc.com/AAAA', local_dns) == '2001:db8::d:3'
+          - lookup('community.general.dig', 'srv001.example.com/AAAA', local_dns)   == '2001:db9::1'
+
+    - name: IPv6 Reverse lookups
+      ansible.builtin.assert:
+        that:
+          - lookup('community.general.dig', '2001:db8::1/PTR', local_dns)   == 'srv001.acme-inc.com.'
+          - lookup('community.general.dig', '2001:db8::2/PTR', local_dns)   == 'srv002.acme-inc.com.'
+          - lookup('community.general.dig', '2001:db8::d:1/PTR', local_dns) == 'mail001.acme-inc.com.'
+          - lookup('community.general.dig', '2001:db8::d:2/PTR', local_dns) == 'mail002.acme-inc.com.'
+          - lookup('community.general.dig', '2001:db8::d:3/PTR', local_dns) == 'mail003.acme-inc.com.'
+          - lookup('community.general.dig', '2001:db8::d:3/PTR', local_dns) == 'mail003.acme-inc.com.'
+          - lookup('community.general.dig', '2001:db9::1/PTR', local_dns)   == 'srv001.example.com.'
+
+    - name: NS records lookup
+      ansible.builtin.assert:
+        that:
+          - lookup('community.general.dig', 'acme-inc.com/NS', local_dns).split(',') | sort | join(',') == 'ns1.acme-inc.com.,ns2.acme-inc.com.'
+          - lookup('community.general.dig', 'example.com/NS', local_dns).split(',')  | sort | join(',') == 'ns1.acme-inc.com.,ns2.acme-inc.com.'
+
+    - name: MX records lookup
+      ansible.builtin.assert:
+        that:
+          - lookup('community.general.dig', 'acme-inc.com/MX', local_dns).split(',') | sort | join(',') == '10 mail001.acme-inc.com.,20 mail002.acme-inc.com.'
+          - lookup('community.general.dig', 'example.com/MX', local_dns).split(',')  | sort | join(',') == '10 mail001.example.com.'
+
+    - name: Service records lookup
+      ansible.builtin.assert:
+        that:
+          - lookup('community.general.dig', '_ldap._tcp.acme-inc.com/SRV', local_dns) == '0 100 88 srv010.acme-inc.com.'
+
+    - name: TXT records lookup
+      ansible.builtin.assert:
+        that:
+          - lookup('community.general.dig', '_kerberos.acme-inc.com/TXT', local_dns) == 'KERBEROS.ACME-INC.COM'
+          - lookup('community.general.dig', 'acme-inc.com/TXT', local_dns).split(',') | sort | join(',') == 'more text,some text'

--- a/tasks/build_host_dicts.yml
+++ b/tasks/build_host_dicts.yml
@@ -43,3 +43,15 @@
         bind_zone_auxiliary: "{{ bind_zone_auxiliary | default({}) | combine({zone.name: {'forwarders_dict': {item: {'ip': item}}}}, recursive=True) }}"
       when: item.port is not defined
       with_items: "{{ zone.forwarders }}"
+
+- name: Set masterfile_format for text
+  ansible.builtin.set_fact:
+    bind_zone_auxiliary: "{{ bind_zone_auxiliary | default({}) | combine({zone.name: {'masterfile_format': 'text'}}, recursive=True) }}"
+  when: item.masterfile_format is not defined or item.masterfile_format == 'text'
+
+- name: Set masterfile_format for raw
+  ansible.builtin.set_fact:
+    bind_zone_auxiliary: "{{ bind_zone_auxiliary | default({}) | combine({zone.name: {'masterfile_format': 'raw'}}, recursive=True) }}"
+  when:
+    - item.masterfile_format is defined
+    - item.masterfile_format == 'raw'

--- a/tasks/build_host_dicts.yml
+++ b/tasks/build_host_dicts.yml
@@ -1,6 +1,7 @@
 ---
 - name: Build primaries dict
   when: zone.primaries is defined
+  tags: bind
   block:
     - name: Convert primaries with port
       ansible.builtin.set_fact:
@@ -16,6 +17,7 @@
 
 - name: Build also_notify dict
   when: zone.also_notify is defined
+  tags: bind
   block:
     - name: Convert also_notify with port
       ansible.builtin.set_fact:
@@ -31,6 +33,7 @@
 
 - name: Build zone forwarders dict
   when: zone.forwarders is defined
+  tags: bind
   block:
     - name: Convert forwarders with port
       ansible.builtin.set_fact:
@@ -47,11 +50,13 @@
 - name: Set masterfile_format for text
   ansible.builtin.set_fact:
     bind_zone_auxiliary: "{{ bind_zone_auxiliary | default({}) | combine({zone.name: {'masterfile_format': 'text'}}, recursive=True) }}"
-  when: item.masterfile_format is not defined or item.masterfile_format == 'text'
+  when: zone.masterfile_format is not defined or zone.masterfile_format == 'text'
+  tags: bind
 
 - name: Set masterfile_format for raw
   ansible.builtin.set_fact:
     bind_zone_auxiliary: "{{ bind_zone_auxiliary | default({}) | combine({zone.name: {'masterfile_format': 'raw'}}, recursive=True) }}"
   when:
-    - item.masterfile_format is defined
-    - item.masterfile_format == 'raw'
+    - zone.masterfile_format is defined
+    - zone.masterfile_format == 'raw'
+  tags: bind

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -98,6 +98,15 @@
   check_mode: false
   tags: bind
 
+- name: Ensure bind_conf_dir exists
+  ansible.builtin.file:
+    path: "{{ bind_conf_dir }}"
+    owner: "root"
+    group: "{{ bind_group }}"
+    mode: "02745"
+    state: directory
+  when: not bind_manage_service
+
 # file to set keys for XFR authentication
 - name: Create extra config for authenticated XFR request
   ansible.builtin.template:
@@ -171,14 +180,9 @@
   failed_when: check_named.rc not in [0,1]
   changed_when: false
 
-- name: Ensure bind_conf_dir exists
-  ansible.builtin.file:
-    path: "{{ bind_conf_dir }}"
-    owner: "root"
-    group: "{{ bind_group }}"
-    mode: "02745"
-    state: directory
-  when: not bind_manage_service
+- name: show templating results
+  ansible.builtin.debug:
+    msg: "{{ lookup('ansible.builtin.template', './etc_named.conf.j2') }}"
 
 - name: Main BIND config file (with validation)
   ansible.builtin.template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -180,10 +180,6 @@
   failed_when: check_named.rc not in [0,1]
   changed_when: false
 
-- name: show templating results
-  ansible.builtin.debug:
-    msg: "{{ lookup('ansible.builtin.template', './etc_named.conf.j2') }}"
-
 - name: Main BIND config file (with validation)
   ansible.builtin.template:
     src: etc_named.conf.j2

--- a/tasks/zones.yml
+++ b/tasks/zones.yml
@@ -248,7 +248,7 @@
   tags: bind
   block:
     - name: Compile forward lookup zone files
-      ansible.builtin.shell: "named-compilezone -f text -F raw -o {{ bind_zone_dir }}/{{ zone_file.item.name }} {{ zone_file.item.name }} {{ zone_file.dest }}"
+      ansible.builtin.command: "named-compilezone -f text -F raw -o {{ bind_zone_dir }}/{{ zone_file.item.name }} {{ zone_file.item.name }} {{ zone_file.dest }}"
       when:
         - zone_file.changed
         - bind_zone_auxiliary[zone_file.item.name].masterfile_format == 'raw'
@@ -258,7 +258,8 @@
         loop_var: zone_file
 
     - name: Compile reverse lookup zone files
-      ansible.builtin.shell: "named-compilezone -f text -F raw -o {{ zone_file.dest | regex_replace('^(.*)\\.text$', '\\1') }} {{ zone_file.dest | regex_search('([^\/]+(?=\/$|\\.text$))', '\\1') | first }} {{ zone_file.dest }}"
+      ansible.builtin.command: "named-compilezone -f text -F raw -o {{ zone_file.dest | regex_replace('^(.*)\\.text$', '\\1') }}
+                              {{ zone_file.dest | regex_search('([^\/]+(?=\/$|\\.text$))', '\\1') | first }} {{ zone_file.dest }}"
       when:
         - zone_file.changed
         - bind_reverse_lookup_zone_masterfile_format == 'raw'
@@ -268,7 +269,8 @@
         loop_var: zone_file
 
     - name: Compile IPv6 reverse lookup zone files
-      ansible.builtin.shell: "named-compilezone -f text -F raw -o {{ zone_file.dest | regex_replace('^(.*)\\.text$', '\\1')  }} {{ zone_file.dest | regex_search('([^\/]+(?=\/$|\\.text$))', '\\1') | first }} {{ zone_file.dest }}"
+      ansible.builtin.command: "named-compilezone -f text -F raw -o {{ zone_file.dest | regex_replace('^(.*)\\.text$', '\\1') }}
+                              {{ zone_file.dest | regex_search('([^\/]+(?=\/$|\\.text$))', '\\1') | first }} {{ zone_file.dest }}"
       when:
         - zone_file.changed
         - bind_reverse_lookup_zone_masterfile_format == 'raw'

--- a/tasks/zones.yml
+++ b/tasks/zones.yml
@@ -22,7 +22,7 @@
   tags: bind
 
 - name: Read reverse ipv4 zone hashes
-  ansible.builtin.shell: "grep -s \"^; Hash:\" {{ bind_zone_dir }}/{{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa
+  ansible.builtin.shell: "grep -s \"^; Hash:\" {{ bind_zone_dir }}/{{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa\
                           {{'.text' if bind_reverse_lookup_zone_masterfile_format == 'raw' }} || true"
   changed_when: false
   check_mode: false
@@ -49,7 +49,7 @@
   tags: bind
 
 - name: Read reverse ipv6 zone hashes
-  ansible.builtin.shell: "grep -s \"^; Hash:\" {{ bind_zone_dir }}/{{ (item.1 | ansible.utils.ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }}
+  ansible.builtin.shell: "grep -s \"^; Hash:\" {{ bind_zone_dir }}/{{ (item.1 | ansible.utils.ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }}\
                           {{ '.text' if bind_reverse_lookup_zone_masterfile_format == 'raw' }} || true"
   changed_when: false
   check_mode: false
@@ -81,14 +81,15 @@
   register: check_named
   failed_when: check_named.rc not in [0,1]
   changed_when: false
+  tags: bind
 
 - name: Create lookup zone files (with validation)
   when: check_named.rc == 0
   block:
-    - name: Create forward lookup zone file
+    - name: Create forward lookup zone file (with validation)
       ansible.builtin.template:
         src: bind_zone.j2
-        dest: "{{ bind_zone_dir }}/{{ item.name }}{{'.text' if bind_reverse_lookup_zone_masterfile_format == 'raw' }}"
+        dest: "{{ bind_zone_dir }}/{{ item.name }}{{'.text' if bind_zone_auxiliary[item.name].masterfile_format == 'raw' }}"
         owner: "{{ bind_owner }}"
         group: "{{ bind_group }}"
         mode: "{{ bind_zone_file_mode }}"
@@ -105,9 +106,10 @@
         (item.type is not defined and bind_zone_auxiliary[item.name]['primaries_dict'] is defined and
         (host_all_addresses | intersect(bind_zone_auxiliary[item.name]['primaries_dict'].keys()) | length > 0)))
       notify: Reload bind
+      register: bind_zone_file_creation_result
       tags: bind
 
-    - name: Create reverse lookup zone file
+    - name: Create reverse lookup zone file (with validation)
       ansible.builtin.template:
         src: reverse_zone.j2
         dest: "{{ bind_zone_dir }}/{{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa{{'.text' if bind_reverse_lookup_zone_masterfile_format == 'raw' }}"
@@ -130,9 +132,10 @@
         (item[0].type is not defined and bind_zone_auxiliary[item[0].name]['primaries_dict'] is defined and
         (host_all_addresses | intersect(bind_zone_auxiliary[item[0].name]['primaries_dict'].keys()) | length > 0)))
       notify: Reload bind
+      register: bind_reverse_lookup_file_creation_result
       tags: bind
 
-    - name: Create reverse IPv6 lookup zone file
+    - name: Create reverse IPv6 lookup zone file (with validation)
       ansible.builtin.template:
         src: reverse_zone_ipv6.j2
         dest: "{{ bind_zone_dir }}/{{ (item.1 | ansible.utils.ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }}\
@@ -156,12 +159,13 @@
         (item[0].type is not defined and bind_zone_auxiliary[item[0].name]['primaries_dict'] is defined and
         (host_all_addresses | intersect(bind_zone_auxiliary[item[0].name]['primaries_dict'].keys()) | length > 0)))
       notify: Reload bind
+      register: bind_ipv6_reverse_lookup_file_creation_result
       tags: bind
 
 - name: Create lookup zone files (without validation)
-  when: check_named.rc == 0
+  when: check_named.rc == 1
   block:
-    - name: Create forward lookup zone file
+    - name: Create forward lookup zone file (without validation)
       ansible.builtin.template:
         src: bind_zone.j2
         dest: "{{ bind_zone_dir }}/{{ item.name }}{{'.text' if bind_reverse_lookup_zone_masterfile_format == 'raw' }}"
@@ -179,9 +183,10 @@
         ((item.type is defined and item.type == 'primary') or
         (item.type is not defined and bind_zone_auxiliary[item.name]['primaries_dict'] is defined and
         (host_all_addresses | intersect(bind_zone_auxiliary[item.name]['primaries_dict'].keys()) | length > 0)))
+      register: bind_zone_file_creation_result_no_validation
       tags: bind
 
-    - name: Create reverse lookup zone file
+    - name: Create reverse lookup zone file (without validation)
       ansible.builtin.template:
         src: reverse_zone.j2
         dest: "{{ bind_zone_dir }}/{{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa{{'.text' if bind_reverse_lookup_zone_masterfile_format == 'raw' }}"
@@ -202,12 +207,13 @@
         ((item[0].type is defined and item[0].type == 'primary') or
         (item[0].type is not defined and bind_zone_auxiliary[item[0].name]['primaries_dict'] is defined and
         (host_all_addresses | intersect(bind_zone_auxiliary[item[0].name]['primaries_dict'].keys()) | length > 0)))
+      register: bind_reverse_lookup_file_creation_result_no_validation
       tags: bind
 
-    - name: Create reverse IPv6 lookup zone file
+    - name: Create reverse IPv6 lookup zone file (without validation)
       ansible.builtin.template:
         src: reverse_zone_ipv6.j2
-        dest: "{{ bind_zone_dir }}/{{ (item.1 | ansible.utils.ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }}
+        dest: "{{ bind_zone_dir }}/{{ (item.1 | ansible.utils.ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }}\
                 {{ '.text' if bind_reverse_lookup_zone_masterfile_format == 'raw' }}"
         owner: "{{ bind_owner }}"
         group: "{{ bind_group }}"
@@ -226,4 +232,47 @@
         ((item[0].type is defined and item[0].type == 'primary') or
         (item[0].type is not defined and bind_zone_auxiliary[item[0].name]['primaries_dict'] is defined and
         (host_all_addresses | intersect(bind_zone_auxiliary[item[0].name]['primaries_dict'].keys()) | length > 0)))
+      register: bind_ipv6_reverse_lookup_file_creation_result_no_validation
       tags: bind
+
+- name: Check if named-compilezone is available
+  ansible.builtin.command:
+    which named-compilezone
+  register: check_named
+  failed_when: check_named.rc not in [0,1]
+  changed_when: false
+  tags: bind
+
+- name: Compile zone files (if raw format)
+  when: check_named.rc == 0
+  tags: bind
+  block:
+    - name: Compile forward lookup zone files
+      ansible.builtin.shell: "named-compilezone -f text -F raw -o {{ bind_zone_dir }}/{{ zone_file.item.name }} {{ zone_file.item.name }} {{ zone_file.dest }}"
+      when:
+        - zone_file.changed
+        - bind_zone_auxiliary[zone_file.item.name].masterfile_format == 'raw'
+      changed_when: zone_file.changed
+      with_items: "{{ bind_zone_file_creation_result.results + bind_zone_file_creation_result_no_validation.results }}"
+      loop_control:
+        loop_var: zone_file
+
+    - name: Compile reverse lookup zone files
+      ansible.builtin.shell: "named-compilezone -f text -F raw -o {{ zone_file.dest | regex_replace('^(.*)\\.text$', '\\1') }} {{ zone_file.dest | regex_search('([^\/]+(?=\/$|\\.text$))', '\\1') | first }} {{ zone_file.dest }}"
+      when:
+        - zone_file.changed
+        - bind_reverse_lookup_zone_masterfile_format == 'raw'
+      changed_when: zone_file.changed
+      with_items: "{{ bind_reverse_lookup_file_creation_result.results + bind_reverse_lookup_file_creation_result_no_validation.results }}"
+      loop_control:
+        loop_var: zone_file
+
+    - name: Compile IPv6 reverse lookup zone files
+      ansible.builtin.shell: "named-compilezone -f text -F raw -o {{ zone_file.dest | regex_replace('^(.*)\\.text$', '\\1')  }} {{ zone_file.dest | regex_search('([^\/]+(?=\/$|\\.text$))', '\\1') | first }} {{ zone_file.dest }}"
+      when:
+        - zone_file.changed
+        - bind_reverse_lookup_zone_masterfile_format == 'raw'
+      changed_when: zone_file.changed
+      with_items: "{{ bind_ipv6_reverse_lookup_file_creation_result.results + bind_ipv6_reverse_lookup_file_creation_result_no_validation.results }}"
+      loop_control:
+        loop_var: zone_file

--- a/tasks/zones.yml
+++ b/tasks/zones.yml
@@ -22,7 +22,8 @@
   tags: bind
 
 - name: Read reverse ipv4 zone hashes
-  ansible.builtin.shell: "grep -s \"^; Hash:\" {{ bind_zone_dir }}/{{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa{{'.text' if bind_reverse_lookup_zone_masterfile_format == 'raw' }} || true"
+  ansible.builtin.shell: "grep -s \"^; Hash:\" {{ bind_zone_dir }}/{{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa
+                          {{'.text' if bind_reverse_lookup_zone_masterfile_format == 'raw' }} || true"
   changed_when: false
   check_mode: false
   register: reverse_hashes_temp
@@ -48,7 +49,8 @@
   tags: bind
 
 - name: Read reverse ipv6 zone hashes
-  ansible.builtin.shell: "grep -s \"^; Hash:\" {{ bind_zone_dir }}/{{ (item.1 | ansible.utils.ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }}{{ '.text' if bind_reverse_lookup_zone_masterfile_format == 'raw' }} || true"
+  ansible.builtin.shell: "grep -s \"^; Hash:\" {{ bind_zone_dir }}/{{ (item.1 | ansible.utils.ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }}
+                          {{ '.text' if bind_reverse_lookup_zone_masterfile_format == 'raw' }} || true"
   changed_when: false
   check_mode: false
   register: reverse_hashes_ipv6_temp
@@ -113,7 +115,7 @@
         group: "{{ bind_group }}"
         mode: "{{ bind_zone_file_mode }}"
         setype: named_zone_t
-        validate: "named-checkzone {{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa{{'.text' if bind_reverse_lookup_zone_masterfile_format == 'raw' }} %s"
+        validate: "named-checkzone {{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa %s"
       become: true
       with_subelements:
         - "{{ bind_zones }}"
@@ -133,14 +135,13 @@
     - name: Create reverse IPv6 lookup zone file
       ansible.builtin.template:
         src: reverse_zone_ipv6.j2
-        dest: "{{ bind_zone_dir }}/{{ (item.1 | ansible.utils.ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }}{{ '.text' if bind_reverse_lookup_zone_masterfile_format == 'raw' }}"
+        dest: "{{ bind_zone_dir }}/{{ (item.1 | ansible.utils.ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }}\
+              {{ '.text' if bind_reverse_lookup_zone_masterfile_format == 'raw' }}"
         owner: "{{ bind_owner }}"
         group: "{{ bind_group }}"
         mode: "{{ bind_zone_file_mode }}"
         setype: named_zone_t
-        validate: >-
-          named-checkzone {{ (item.1 | ansible.utils.ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):] }}
-          {{ '.text' if bind_reverse_lookup_zone_masterfile_format == 'raw' }} %s
+        validate: "named-checkzone {{ (item.1 | ansible.utils.ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):] }} %s"
       become: true
       with_subelements:
         - "{{ bind_zones }}"
@@ -206,7 +207,8 @@
     - name: Create reverse IPv6 lookup zone file
       ansible.builtin.template:
         src: reverse_zone_ipv6.j2
-        dest: "{{ bind_zone_dir }}/{{ (item.1 | ansible.utils.ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }}{{ '.text' if bind_reverse_lookup_zone_masterfile_format == 'raw' }}"
+        dest: "{{ bind_zone_dir }}/{{ (item.1 | ansible.utils.ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }}
+                {{ '.text' if bind_reverse_lookup_zone_masterfile_format == 'raw' }}"
         owner: "{{ bind_owner }}"
         group: "{{ bind_group }}"
         mode: "{{ bind_zone_file_mode }}"

--- a/tasks/zones.yml
+++ b/tasks/zones.yml
@@ -1,6 +1,6 @@
 ---
 - name: Read forward zone hashes
-  ansible.builtin.shell: 'grep -s "^; Hash:" {{ bind_zone_dir }}/{{ item.name }} || true'
+  ansible.builtin.shell: "grep -s \"^; Hash:\" {{ bind_zone_dir }}/{{ item.name }}{{'.text' if bind_zone_auxiliary[item.name]['masterfile_format'] == 'raw' }} || true"
   changed_when: false
   check_mode: false
   register: forward_hashes_temp
@@ -22,7 +22,7 @@
   tags: bind
 
 - name: Read reverse ipv4 zone hashes
-  ansible.builtin.shell: "grep -s \"^; Hash:\" {{ bind_zone_dir }}/{{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa || true"
+  ansible.builtin.shell: "grep -s \"^; Hash:\" {{ bind_zone_dir }}/{{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa{{'.text' if bind_reverse_lookup_zone_masterfile_format == 'raw' }} || true"
   changed_when: false
   check_mode: false
   register: reverse_hashes_temp
@@ -48,7 +48,7 @@
   tags: bind
 
 - name: Read reverse ipv6 zone hashes
-  ansible.builtin.shell: "grep -s \"^; Hash:\" {{ bind_zone_dir }}/{{ (item.1 | ansible.utils.ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }} || true"
+  ansible.builtin.shell: "grep -s \"^; Hash:\" {{ bind_zone_dir }}/{{ (item.1 | ansible.utils.ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }}{{ '.text' if bind_reverse_lookup_zone_masterfile_format == 'raw' }} || true"
   changed_when: false
   check_mode: false
   register: reverse_hashes_ipv6_temp
@@ -86,7 +86,7 @@
     - name: Create forward lookup zone file
       ansible.builtin.template:
         src: bind_zone.j2
-        dest: "{{ bind_zone_dir }}/{{ item.name }}"
+        dest: "{{ bind_zone_dir }}/{{ item.name }}{{'.text' if bind_reverse_lookup_zone_masterfile_format == 'raw' }}"
         owner: "{{ bind_owner }}"
         group: "{{ bind_group }}"
         mode: "{{ bind_zone_file_mode }}"
@@ -108,12 +108,12 @@
     - name: Create reverse lookup zone file
       ansible.builtin.template:
         src: reverse_zone.j2
-        dest: "{{ bind_zone_dir }}/{{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa"
+        dest: "{{ bind_zone_dir }}/{{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa{{'.text' if bind_reverse_lookup_zone_masterfile_format == 'raw' }}"
         owner: "{{ bind_owner }}"
         group: "{{ bind_group }}"
         mode: "{{ bind_zone_file_mode }}"
         setype: named_zone_t
-        validate: "named-checkzone {{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa %s"
+        validate: "named-checkzone {{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa{{'.text' if bind_reverse_lookup_zone_masterfile_format == 'raw' }} %s"
       become: true
       with_subelements:
         - "{{ bind_zones }}"
@@ -133,12 +133,14 @@
     - name: Create reverse IPv6 lookup zone file
       ansible.builtin.template:
         src: reverse_zone_ipv6.j2
-        dest: "{{ bind_zone_dir }}/{{ (item.1 | ansible.utils.ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }}"
+        dest: "{{ bind_zone_dir }}/{{ (item.1 | ansible.utils.ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }}{{ '.text' if bind_reverse_lookup_zone_masterfile_format == 'raw' }}"
         owner: "{{ bind_owner }}"
         group: "{{ bind_group }}"
         mode: "{{ bind_zone_file_mode }}"
         setype: named_zone_t
-        validate: "named-checkzone {{ (item.1 | ansible.utils.ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):] }} %s"
+        validate: >-
+          named-checkzone {{ (item.1 | ansible.utils.ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):] }}
+          {{ '.text' if bind_reverse_lookup_zone_masterfile_format == 'raw' }} %s
       become: true
       with_subelements:
         - "{{ bind_zones }}"
@@ -161,7 +163,7 @@
     - name: Create forward lookup zone file
       ansible.builtin.template:
         src: bind_zone.j2
-        dest: "{{ bind_zone_dir }}/{{ item.name }}"
+        dest: "{{ bind_zone_dir }}/{{ item.name }}{{'.text' if bind_reverse_lookup_zone_masterfile_format == 'raw' }}"
         owner: "{{ bind_owner }}"
         group: "{{ bind_group }}"
         mode: "{{ bind_zone_file_mode }}"
@@ -181,7 +183,7 @@
     - name: Create reverse lookup zone file
       ansible.builtin.template:
         src: reverse_zone.j2
-        dest: "{{ bind_zone_dir }}/{{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa"
+        dest: "{{ bind_zone_dir }}/{{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa{{'.text' if bind_reverse_lookup_zone_masterfile_format == 'raw' }}"
         owner: "{{ bind_owner }}"
         group: "{{ bind_group }}"
         mode: "{{ bind_zone_file_mode }}"
@@ -204,7 +206,7 @@
     - name: Create reverse IPv6 lookup zone file
       ansible.builtin.template:
         src: reverse_zone_ipv6.j2
-        dest: "{{ bind_zone_dir }}/{{ (item.1 | ansible.utils.ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }}"
+        dest: "{{ bind_zone_dir }}/{{ (item.1 | ansible.utils.ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }}{{ '.text' if bind_reverse_lookup_zone_masterfile_format == 'raw' }}"
         owner: "{{ bind_owner }}"
         group: "{{ bind_group }}"
         mode: "{{ bind_zone_file_mode }}"

--- a/templates/etc_named.conf.j2
+++ b/templates/etc_named.conf.j2
@@ -175,6 +175,9 @@ include "{{ bind_tsig_file }}";
 {# End: set mapped primaries for the zone #}
 {# {{ _mapped_zone_primaries }} #}
 zone "{{ bind_zone.name }}" IN {
+{% if bind_zone.masterfile_format is defined %}
+  masterfile-format {{ bind_zone.masterfile_format }};
+{% endif %}
 {% if _type == 'primary' %}
   type master;
   file "{{ bind_zone_dir }}/{{ bind_zone.name }}";
@@ -233,6 +236,9 @@ zone "{{ bind_zone.name }}" IN {
 {% for network in bind_zone.networks %}
 
 zone "{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr.arpa" IN {
+{% if bind_reverse_lookup_zone_masterfile_format | length > 0 %}
+  masterfile-format {{ bind_reverse_lookup_zone_masterfile_format }};
+{% endif %}
 {% if _type == 'primary' %}
   type master;
   file "{{ bind_zone_dir }}/{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr.arpa";
@@ -292,6 +298,9 @@ zone "{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr
 {% for network in bind_zone.ipv6_networks %}
 
 zone "{{ (network | ansible.utils.ipaddr('revdns'))[-(9+(network|regex_replace('^.*/','')|int)//2):] }}" IN {
+{% if bind_reverse_lookup_zone_masterfile_format | length > 0 %}
+  masterfile-format {{ bind_reverse_lookup_zone_masterfile_format }};
+{% endif %}
 {% if _type == 'primary' %}
   type master;
   file "{{ bind_zone_dir }}/{{ (network | ansible.utils.ipaddr('revdns'))[-(9+(network|regex_replace('^.*/','')|int)//2):-1] }}";


### PR DESCRIPTION
Added support for `masterfile-format` setting for zones and reverse zones:
- setting `masterfile_format` for each `bind_zone`
- global setting `bind_reverse_lookup_zone_masterfile_format` for reverse lookup zones

Allowed values are `text` and  `raw`.