### PR TITLE
feature: Added support for `allow-notify` per zone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up Python 3
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
       - name: Install test dependencies
         run: pip3 install yamllint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Python 3
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-
       - name: Install test dependencies
         run: pip3 install yamllint
 
@@ -31,7 +26,7 @@ jobs:
           yamllint .
 
       - name: Run ansible-lint
-        uses: ansible/ansible-lint@v24.12.2
+        uses: ansible/ansible-lint@v25
   molecule:
     name: Molecule
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The following Ansible collections are required:
 | `bind_zones`                                       | n/a                  | A list of mappings with zone definitions. See below this table for examples                                                          |
 | `- allow_update`                                   | `['none']`           | A list of hosts that are allowed to dynamically update this DNS zone.                                                                |
 | `- also_notify`                                    | -                    | A list of servers that will receive a notification when the primary zone file is reloaded.                                           |
+| `- allow_notify`                                   | -                    | A list of servers from which a zone update notification is accepted.                                                                 |
 | `- create_forward_zones`                           | -                    | When initialized and set to `false`, creation of forward zones will be skipped (resulting in a reverse only zone)                    |
 | `- create_reverse_zones`                           | -                    | When initialized and set to `false`, creation of reverse zones will be skipped (resulting in a forward only zone)                    |
 | `- delegate`                                       | `[]`                 | Zone delegation.                                                                                                                     |

--- a/molecule/config_first_then_package/group_vars/all.yml
+++ b/molecule/config_first_then_package/group_vars/all.yml
@@ -70,6 +70,8 @@ bind_zones:
       - ns2
     also_notify:
       - 10.11.0.5
+    allow_notify:
+      - 10.11.0.4
     hosts:
       - name: ns1
         ip: 10.11.0.4

--- a/molecule/config_only/prepare.yml
+++ b/molecule/config_only/prepare.yml
@@ -3,7 +3,7 @@
 # Remark that common variables are defined in `group_vars/all.yml`
 
 - name: Primary/Secondary with Shared Inventory
-  hosts: dns
+  hosts: all
   pre_tasks:
     - name: "Old Debian: Switch source repo to archive "
       ansible.builtin.replace:

--- a/molecule/config_only/prepare.yml
+++ b/molecule/config_only/prepare.yml
@@ -5,12 +5,6 @@
 - name: Primary/Secondary with Shared Inventory
   hosts: dns
   pre_tasks:
-    - name: Set zone-file owner
-      ansible.builtin.set_fact:
-        bind_zone_file_owner_override: "bind"
-        bind_zone_file_group_override: "bind"
-      when: ansible_distribution == 'Debian'
-
     - name: "Old Debian: Switch source repo to archive "
       ansible.builtin.replace:
         path: /etc/apt/sources.list

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -3,7 +3,7 @@
 # Remark that common variables are defined in `group_vars/all.yml`
 
 - name: Primary/Secondary with Shared Inventory
-  hosts: dns
+  hosts: all
   pre_tasks:
     - name: "Old Debian: Switch source repo to archive "
       ansible.builtin.replace:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -5,12 +5,6 @@
 - name: Primary/Secondary with Shared Inventory
   hosts: dns
   pre_tasks:
-    - name: Set zone-file owner
-      ansible.builtin.set_fact:
-        bind_zone_file_owner_override: "bind"
-        bind_zone_file_group_override: "bind"
-      when: ansible_distribution == 'Debian'
-
     - name: "Old Debian: Switch source repo to archive "
       ansible.builtin.replace:
         path: /etc/apt/sources.list

--- a/molecule/shared_inventory/prepare.yml
+++ b/molecule/shared_inventory/prepare.yml
@@ -3,7 +3,7 @@
 # Remark that common variables are defined in `group_vars/all.yml`
 
 - name: Primary/Secondary with Shared Inventory
-  hosts: dns
+  hosts: all
   pre_tasks:
     - name: "Old Debian: Switch source repo to archive "
       ansible.builtin.replace:

--- a/molecule/shared_inventory/prepare.yml
+++ b/molecule/shared_inventory/prepare.yml
@@ -5,12 +5,6 @@
 - name: Primary/Secondary with Shared Inventory
   hosts: dns
   pre_tasks:
-    - name: Set zone-file owner
-      ansible.builtin.set_fact:
-        bind_zone_file_owner_override: "bind"
-        bind_zone_file_group_override: "bind"
-      when: ansible_distribution == 'Debian'
-
     - name: "Old Debian: Switch source repo to archive "
       ansible.builtin.replace:
         path: /etc/apt/sources.list

--- a/molecule/shared_inventory_nonstandard_ports/prepare.yml
+++ b/molecule/shared_inventory_nonstandard_ports/prepare.yml
@@ -3,7 +3,7 @@
 # Remark that common variables are defined in `group_vars/all.yml`
 
 - name: Primary/Secondary with Shared Inventory
-  hosts: dns
+  hosts: all
   pre_tasks:
     - name: "Old Debian: Switch source repo to archive "
       ansible.builtin.replace:

--- a/molecule/shared_inventory_nonstandard_ports/prepare.yml
+++ b/molecule/shared_inventory_nonstandard_ports/prepare.yml
@@ -5,12 +5,6 @@
 - name: Primary/Secondary with Shared Inventory
   hosts: dns
   pre_tasks:
-    - name: Set zone-file owner
-      ansible.builtin.set_fact:
-        bind_zone_file_owner_override: "bind"
-        bind_zone_file_group_override: "bind"
-      when: ansible_distribution == 'Debian'
-
     - name: "Old Debian: Switch source repo to archive "
       ansible.builtin.replace:
         path: /etc/apt/sources.list

--- a/molecule/shared_inventory_raw/prepare.yml
+++ b/molecule/shared_inventory_raw/prepare.yml
@@ -3,7 +3,7 @@
 # Remark that common variables are defined in `group_vars/all.yml`
 
 - name: Primary/Secondary with Shared Inventory
-  hosts: dns
+  hosts: all
   pre_tasks:
     - name: "Old Debian: Switch source repo to archive "
       ansible.builtin.replace:

--- a/molecule/shared_inventory_raw/prepare.yml
+++ b/molecule/shared_inventory_raw/prepare.yml
@@ -5,12 +5,6 @@
 - name: Primary/Secondary with Shared Inventory
   hosts: dns
   pre_tasks:
-    - name: Set zone-file owner
-      ansible.builtin.set_fact:
-        bind_zone_file_owner_override: "bind"
-        bind_zone_file_group_override: "bind"
-      when: ansible_distribution == 'Debian'
-
     - name: "Old Debian: Switch source repo to archive "
       ansible.builtin.replace:
         path: /etc/apt/sources.list

--- a/templates/etc_named.conf.j2
+++ b/templates/etc_named.conf.j2
@@ -230,6 +230,15 @@ zone "{{ bind_zone.name }}" IN {
   notify explicit;
   masters { {{ _primaries | join('; ') }}; };
   file "{{ bind_secondary_dir }}/{{ bind_zone.name }}";
+{% if bind_zone.allow_notify is defined %}
+  allow-notify {
+{% for upstream in bind_zone.allow_notify %}
+{% if upstream not in host_all_addresses %}
+    {{ upstream }};
+{% endif %}
+{% endfor %}
+  };
+{% endif %}
 {% elif _type == 'forward' %}
   type forward;
   forward only;
@@ -293,6 +302,15 @@ zone "{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr
   type slave;
   masters { {{ _primaries | join('; ') }}; };
   file "{{ bind_secondary_dir }}/{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr.arpa";
+{% if bind_zone.allow_notify is defined %}
+  allow-notify {
+{% for upstream in bind_zone.allow_notify %}
+{% if upstream not in host_all_addresses %}
+    {{ upstream }};
+{% endif %}
+{% endfor %}
+  };
+{% endif %}
 {% elif _type == 'forward' %}
   type forward;
   forward only;
@@ -355,6 +373,15 @@ zone "{{ (network | ansible.utils.ipaddr('revdns'))[-(9+(network|regex_replace('
   type slave;
   masters { {{ _primaries | join('; ') }}; };
   file "{{ bind_secondary_dir }}/{{ (network | ansible.utils.ipaddr('revdns'))[-(9+(network|regex_replace('^.*/','')|int)//2):-1] }}";
+{% if bind_zone.allow_notify is defined %}
+  allow-notify {
+{% for upstream in bind_zone.allow_notify %}
+{% if upstream not in host_all_addresses %}
+    {{ upstream }};
+{% endif %}
+{% endfor %}
+  };
+{% endif %}
 {% elif _type == 'forward' %}
   type forward;
   forward only;


### PR DESCRIPTION
It is now possible to specify a list of allow-notify entries per zone for secondary zones
```yaml
bind_zones:
  - name: 'acme-inc.com'
    primaries:
      - 10.11.0.4
    networks:
      - '10.11'
    ipv6_networks:
      - '2001:db8::/48'
    name_servers:
      - ns1
      - ns2
    also_notify:
      - 10.11.0.5
    allow_notify:
      - 10.11.0.4
...
```