### PR TITLE
Feature: Support Debian 13 Trixie

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
           - debian10
           - debian11
           - debian12
+          - debian13
           - ubuntu2204
           - ubuntu2404
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ The following Ansible collections are required:
 | `bind_tsig_keys`                                   | `[]`                 | A list of tsig keys, which are mappings with keys `name:` `algorithm:` and `secret:`. See below for an example.                      |
 | `bind_dns64`                                       | `false`              | If `true`, support for [DNS64](https://www.oreilly.com/library/view/dns-and-bind/9781449308025/ch04.html) is enabled                 |
 | `bind_dns64_clients`                               | `['any']`            | A list of clients which the DNS64 function applies to (can be any ACL)                                                               |
-| `bind_dnssec_enable`                               | `true`               | If `true`, DNSSEC is enabled                                                                                                         |
 | `bind_dnssec_validation`                           | `true`               | If `true`, DNSSEC validation is enabled                                                                                              |
 | `bind_extra_include_files`                         | `[]`                 | A list of custom config files to be included from the main config file                                                               |
 | `bind_forward_only`                                | `false`              | If `true`, BIND is set up as a caching name server                                                                                   |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -69,8 +69,7 @@ bind_statistics_allow:
   - "127.0.0.1"
 
 # DNSSEC configuration
-bind_dnssec_enable: true
-bind_dnssec_validation: true
+bind_dnssec_validation: false
 
 bind_extra_include_files: []
 

--- a/molecule/config_first_then_package/molecule.yml
+++ b/molecule/config_first_then_package/molecule.yml
@@ -25,7 +25,7 @@ platforms:
     networks:
       - name: bind
         ipv4_address: "10.11.0.4"
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian13}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -45,7 +45,7 @@ platforms:
     networks:
       - name: bind
         ipv4_address: "10.11.0.5"
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian13}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw

--- a/molecule/config_only/molecule.yml
+++ b/molecule/config_only/molecule.yml
@@ -25,7 +25,7 @@ platforms:
     networks:
       - name: bind
         ipv4_address: "10.11.0.4"
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian13}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -45,7 +45,7 @@ platforms:
     networks:
       - name: bind
         ipv4_address: "10.11.0.5"
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian13}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw

--- a/molecule/default/group_vars/all.yml
+++ b/molecule/default/group_vars/all.yml
@@ -1,5 +1,6 @@
 ---
 bind_statistics_channels: true
+bind_dnssec_validation: false
 bind_statistics_allow:
   - any
 bind_zone_dir: /var/local/named-zones

--- a/molecule/default/host_vars/ns1.yml
+++ b/molecule/default/host_vars/ns1.yml
@@ -1,6 +1,5 @@
 ---
 # Primary Configuration
-
 bind_zones:
   # Primary server for domain example.com (use zone type autodetection)
   - name: 'example.com'

--- a/molecule/default/host_vars/ns3.yml
+++ b/molecule/default/host_vars/ns3.yml
@@ -1,7 +1,5 @@
 ---
 # Forwarder Configuration
-
-bind_dnssec_validation: false
 bind_zones:
   # Forwarder for domain example.com (use zone type autodetection)
   - name: 'example.com'

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -26,7 +26,7 @@ platforms:
     networks:
       - name: bind
         ipv4_address: "10.11.0.1"
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian13}-ansible:latest"
     # Command to execute when the container starts
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     # Volumes to mount within the container. Important to enable systemd
@@ -50,7 +50,7 @@ platforms:
     networks:
       - name: bind
         ipv4_address: "10.11.0.2"
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian13}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -68,7 +68,7 @@ platforms:
     networks:
       - name: bind
         ipv4_address: "10.11.0.3"
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian13}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw

--- a/molecule/shared_inventory/molecule.yml
+++ b/molecule/shared_inventory/molecule.yml
@@ -25,7 +25,7 @@ platforms:
     networks:
       - name: bind
         ipv4_address: "10.11.0.4"
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian13}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -45,7 +45,7 @@ platforms:
     networks:
       - name: bind
         ipv4_address: "10.11.0.5"
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian13}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw

--- a/molecule/shared_inventory_nonstandard_ports/molecule.yml
+++ b/molecule/shared_inventory_nonstandard_ports/molecule.yml
@@ -25,7 +25,7 @@ platforms:
     networks:
       - name: bind
         ipv4_address: "10.11.0.4"
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian13}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -45,7 +45,7 @@ platforms:
     networks:
       - name: bind
         ipv4_address: "10.11.0.5"
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian13}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw

--- a/molecule/shared_inventory_raw/molecule.yml
+++ b/molecule/shared_inventory_raw/molecule.yml
@@ -25,7 +25,7 @@ platforms:
     networks:
       - name: bind
         ipv4_address: "10.11.0.4"
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian13}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -45,7 +45,7 @@ platforms:
     networks:
       - name: bind
         ipv4_address: "10.11.0.5"
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian12}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian13}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -170,7 +170,7 @@
     (((item.type is defined and item.type == 'primary') or
     (item.type is not defined and bind_zone_auxiliary[item.name]['primaries_dict'] is defined and
     (host_all_addresses | intersect(bind_zone_auxiliary[item.name]['primaries_dict'].keys()) | length > 0))) and
-    (ansible_facts.services[bind_service].state == "running") and (item.allow_update | default(false)))
+    (ansible_facts.services[bind_service].state == "running") and (item.allow_update is defined and item.allow_update | length > 0))
   with_items: '{{ bind_zones }}'
   tags: bind
 
@@ -255,6 +255,6 @@
     (((item.type is defined and item.type == 'primary') or
     (item.type is not defined and bind_zone_auxiliary[item.name]['primaries_dict'] is defined and
     (host_all_addresses | intersect(bind_zone_auxiliary[item.name]['primaries_dict'].keys()) | length > 0))) and
-    (ansible_facts.services[bind_service].state == "running") and (item.allow_update | default(false)))
+    (ansible_facts.services[bind_service].state == "running") and (item.allow_update is defined and item.allow_update | length > 0))
   with_items: '{{ bind_zones }}'
   tags: bind

--- a/tasks/sync_dynamic_zones.yml
+++ b/tasks/sync_dynamic_zones.yml
@@ -34,7 +34,7 @@
   tags: bind
 
 - name: Dump/flush dynamic ipv6 reverse zone changes to disk/zone file
-  ansible.builtin.command: "rndc sync -clean {{ (item.1 | ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }}"
+  ansible.builtin.command: "rndc sync -clean {{ (item.1 | ansible.utils.ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }}"
   with_subelements:
     - "{{ bind_zones }}"
     - ipv6_networks

--- a/vars/Debian-13.yml
+++ b/vars/Debian-13.yml
@@ -1,0 +1,43 @@
+# Distro specific variables for Debian
+---
+bind_default_python_version: '3'
+bind_packages:
+  - "{{ (bind_python_version | string == '3') | ternary('python3-netaddr', 'python-netaddr') }}"
+  - "{{ (bind_python_version | string == '3') | ternary('python3-dnspython', 'python-dnspython') }}"
+  - bind9
+  - bind9-utils
+
+bind_service: named
+
+# Main config file
+bind_config: /etc/bind/named.conf
+
+bind_default_zone_files:
+  # bind9 on Debian 13 moved options configuration to a separate file, the main named.conf
+  # merely includes the following three files.
+  # To keep the integrity of this role, the file named.conf.options is not included
+  # since the options configured by this role are written directly to named.conf.
+  # - /etc/bind/named.conf.options
+  - /etc/bind/named.conf.local
+  - /etc/bind/named.conf.root-hints
+
+# Directory with run-time stuff
+bind_dir: /var/cache/bind
+bind_conf_dir: "/etc/bind"
+auth_file: "auth_transfer.conf"
+bind_auth_file: "{{ bind_conf_dir }}/{{ auth_file }}"
+
+# tsig key file
+tsig_file: "tsig_keys.conf"
+bind_tsig_file: "{{ bind_conf_dir }}/{{ tsig_file }}"
+
+bind_owner: root
+bind_group: bind
+
+bind_bindkeys_file: ""
+bind_pid_file: "/run/named/named.pid"
+bind_session_keyfile: "/run/named/session.key"
+
+# Custom location for zone files
+bind_zone_dir: "{{ bind_dir }}"
+bind_secondary_dir: "{{ bind_dir }}/secondary"


### PR DESCRIPTION
Added support for Debian 13 Trixie
This contains a potentially breaking change:

[Disable dnssec-validation by default](https://github.com/Salvoxia/ansible-role-bind/commit/d8b3b8dc4dc3bf2b262f006d00b38aefab3ee992)

In previous BIND versions, setting `dnssec-validation` to yes had no effect until trust-anchors were explicitly configured.
In newer versions, BIND will not start if `dnssec-validation` is set to yes and no trust-anchors are configured.
Thus, the default in the role is changed to no, not changing the roles behavior if no trust-anchors were configured, but remaining compatible to newer BIND versions.