### PR TITLE
chore: Use `molecule-plugins[docker]` instead of `molecule-docker`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies (CentOS 8 / Debian 10).
-        run: pip3 install ansible==9.13.0 molecule molecule-docker yamllint ansible-lint docker netaddr dnspython ansible-compat>=25.1.4
+        run: pip3 install ansible==9.13.0 molecule molecule-plugins[docker] yamllint ansible-lint docker netaddr dnspython ansible-compat>=25.1.4
         if: matrix.distro == 'centos8' || matrix.distro == 'debian10'
 
       # community.general version >= 9.5.0 is required for the 'dig' lookup filter to support the 'port' parameter
@@ -62,7 +62,7 @@ jobs:
         if: matrix.distro == 'centos8' || matrix.distro == 'debian10'
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule molecule-docker yamllint ansible-lint docker netaddr dnspython ansible-compat>=25.1.4
+        run: pip3 install ansible molecule molecule-plugins[docker] yamllint ansible-lint docker netaddr dnspython ansible-compat>=25.1.4
         if: matrix.distro != 'centos8' && matrix.distro != 'debian10'
 
       - name: Run Molecule Primary/Secondary/Forwarder tests

--- a/.github/workflows/galaxy.yml
+++ b/.github/workflows/galaxy.yml
@@ -52,7 +52,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies (CentOS 8 / Debian 10).
-        run: pip3 install ansible==9.13.0 molecule molecule-docker yamllint ansible-lint docker netaddr dnspython ansible-compat>=25.1.4
+        run: pip3 install ansible==9.13.0 molecule molecule-plugins[docker] yamllint ansible-lint docker netaddr dnspython ansible-compat>=25.1.4
         if: matrix.distro == 'centos8' || matrix.distro == 'debian10'
 
       # community.general version >= 9.5.0 is required for the 'dig' lookup filter to support the 'port' parameter
@@ -61,7 +61,7 @@ jobs:
         if: matrix.distro == 'centos8' || matrix.distro == 'debian10'
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule molecule-docker yamllint ansible-lint docker netaddr dnspython ansible-compat>=25.1.4
+        run: pip3 install ansible molecule molecule-plugins[docker] yamllint ansible-lint docker netaddr dnspython ansible-compat>=25.1.4
         if: matrix.distro != 'centos8' && matrix.distro != 'debian10'
 
       - name: Run Molecule Primary/Secondary/Forwarder tests


### PR DESCRIPTION
`molecule-docker` seems to be outdated and containing non-boolean conditionals throwing errors with latest Ansible versions.