### PR TITLE
CI Workflow: Use Python 3.11 / ansible community.general <= 11 for CentoOS 8 / Debian 10 molecule tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,10 @@ jobs:
         run: pip3 install ansible==9.13.0 molecule molecule-plugins[docker] yamllint ansible-lint docker netaddr dnspython ansible-compat>=25.1.4
         if: matrix.distro == 'centos8' || matrix.distro == 'debian10'
 
+      - name: Install community.general specific version
+        run: ansible-galaxy collection install "community.general<12"
+        if: matrix.distro == 'centos8' || matrix.distro == 'debian10'
+
       # community.general version >= 9.5.0 is required for the 'dig' lookup filter to support the 'port' parameter
       - name: Install ansible dependencies (CentOS 8 / Debian 10).
         run: ansible-galaxy collection install community.general>=9.5.0 --force

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
 
       # community.general version >= 9.5.0 is required for the 'dig' lookup filter to support the 'port' parameter
       - name: Install ansible dependencies (CentOS 8 / Debian 10).
-        run: ansible-galaxy collection install 'community.general:>=9.5.0,<=11 --force'
+        run: ansible-galaxy collection install 'community.general:>=9.5.0,<=11' --force
         if: matrix.distro == 'centos8' || matrix.distro == 'debian10'
 
       - name: Install test dependencies.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
 
       # community.general version >= 9.5.0 is required for the 'dig' lookup filter to support the 'port' parameter
       - name: Install ansible dependencies (CentOS 8 / Debian 10).
-        run: ansible-galaxy collection install community.general>=9.5.0,<=11 --force
+        run: ansible-galaxy collection install 'community.general:>=9.5.0,<=11 --force'
         if: matrix.distro == 'centos8' || matrix.distro == 'debian10'
 
       - name: Install test dependencies.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Python 3 (CentOS 8 / Debian 10).
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.12'
         if: matrix.distro == 'centos8' || matrix.distro == 'debian10'
 
       - name: Set up Python 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,13 +63,9 @@ jobs:
         run: pip3 install ansible==9.13.0 molecule molecule-plugins[docker] yamllint ansible-lint docker netaddr dnspython ansible-compat>=25.1.4
         if: matrix.distro == 'centos8' || matrix.distro == 'debian10'
 
-      - name: Install community.general specific version
-        run: ansible-galaxy collection install "community.general<12"
-        if: matrix.distro == 'centos8' || matrix.distro == 'debian10'
-
       # community.general version >= 9.5.0 is required for the 'dig' lookup filter to support the 'port' parameter
       - name: Install ansible dependencies (CentOS 8 / Debian 10).
-        run: ansible-galaxy collection install community.general>=12 --force
+        run: ansible-galaxy collection install community.general>=9.5.0,<=11 --force
         if: matrix.distro == 'centos8' || matrix.distro == 'debian10'
 
       - name: Install test dependencies.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,17 @@ jobs:
       - name: Check out the codebase.
         uses: actions/checkout@v4
 
+      - name: Set up Python 3 (CentOS 8 / Debian 10).
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+        if: matrix.distro == 'centos8' || matrix.distro == 'debian10'
+
       - name: Set up Python 3
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
+        if: matrix.distro != 'centos8' && matrix.distro != 'debian10'
 
       - name: Install test dependencies (CentOS 8 / Debian 10).
         run: pip3 install ansible==9.13.0 molecule molecule-plugins[docker] yamllint ansible-lint docker netaddr dnspython ansible-compat>=25.1.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
 
       # community.general version >= 9.5.0 is required for the 'dig' lookup filter to support the 'port' parameter
       - name: Install ansible dependencies (CentOS 8 / Debian 10).
-        run: ansible-galaxy collection install community.general>=9.5.0 --force
+        run: ansible-galaxy collection install community.general>=12 --force
         if: matrix.distro == 'centos8' || matrix.distro == 'debian10'
 
       - name: Install test dependencies.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set up Python 3 (CentOS 8 / Debian 10).
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.11'
         if: matrix.distro == 'centos8' || matrix.distro == 'debian10'
 
       - name: Set up Python 3

--- a/.github/workflows/galaxy.yml
+++ b/.github/workflows/galaxy.yml
@@ -39,6 +39,7 @@ jobs:
           - debian10
           - debian11
           - debian12
+          - debian13
           - ubuntu2204
           - ubuntu2404
 
@@ -46,10 +47,17 @@ jobs:
       - name: Check out the codebase.
         uses: actions/checkout@v4
 
+      - name: Set up Python 3 (CentOS 8 / Debian 10).
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+        if: matrix.distro == 'centos8' || matrix.distro == 'debian10'
+
       - name: Set up Python 3
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
+        if: matrix.distro != 'centos8' && matrix.distro != 'debian10'
 
       - name: Install test dependencies (CentOS 8 / Debian 10).
         run: pip3 install ansible==9.13.0 molecule molecule-plugins[docker] yamllint ansible-lint docker netaddr dnspython ansible-compat>=25.1.4
@@ -57,7 +65,7 @@ jobs:
 
       # community.general version >= 9.5.0 is required for the 'dig' lookup filter to support the 'port' parameter
       - name: Install ansible dependencies (CentOS 8 / Debian 10).
-        run: ansible-galaxy collection install community.general>=9.5.0 --force
+        run: ansible-galaxy collection install 'community.general:>=9.5.0,<=11' --force
         if: matrix.distro == 'centos8' || matrix.distro == 'debian10'
 
       - name: Install test dependencies.


### PR DESCRIPTION
The `setup-python` action defaulted to install Pyhon 3.14, but for CentOS 8 / Debian 10 no `ansible-core` version compatible with Python 3.14 is available.
Make sure to explicitly install Python 3.11 on CentOS 8 / Debian 10 molecule hosts. Also, use `community.general` collection version `<=11` to ensure compatibility.